### PR TITLE
fix: Running DockerRegistryPolling jobs should not get stuck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
 			<artifactId>kubernetes-client</artifactId>
 			<version>4.6.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.truth</groupId>
+			<artifactId>truth</artifactId>
+			<version>1.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/oneko/docker/DockerRegistryPolling.java
+++ b/src/main/java/io/oneko/docker/DockerRegistryPolling.java
@@ -85,7 +85,8 @@ class DockerRegistryPolling {
 					.collectList();
 			this.currentPollingJob = new DockerRegistryPollingJob(meshesMono.zipWith(projectsMono)
 					.flatMap(pair -> this.checkDockerForNewImages(pair.getT1(), pair.getT2()))
-					.subscribe(nothingness -> log.trace("Finished polling job")), Instant.now()).withTimeoutDuration(pollingTimeoutDuration);
+					.doOnTerminate(() -> log.trace("Finished polling job"))
+					.subscribe(), Instant.now()).withTimeoutDuration(pollingTimeoutDuration);
 		} else if (this.currentPollingJob != null && (this.currentPollingJob.shouldCancel() || this.currentPollingJob.isCancelled())) {
 			log.info("The job timed out. Cancelling it.");
 			this.currentPollingJob.cancel();

--- a/src/main/java/io/oneko/docker/DockerRegistryPollingJob.java
+++ b/src/main/java/io/oneko/docker/DockerRegistryPollingJob.java
@@ -1,0 +1,42 @@
+package io.oneko.docker;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import lombok.Data;
+import reactor.core.Disposable;
+
+@Data
+public class DockerRegistryPollingJob {
+	private Clock clock = Clock.systemDefaultZone();
+	private Duration timeoutDuration = Duration.ofMinutes(5);
+
+	private Disposable job;
+	private Instant startDate;
+
+
+	public DockerRegistryPollingJob(Disposable job, Instant startDate) {
+		this.job = job;
+		this.startDate = startDate;
+	}
+
+	public DockerRegistryPollingJob withTimeoutDuration(Duration timeoutDuration) {
+		if (timeoutDuration != null) {
+			this.timeoutDuration = timeoutDuration;
+		}
+		return this;
+	}
+
+	public boolean shouldCancel() {
+		return startDate != null && clock.instant().minus(timeoutDuration).isAfter(startDate);
+	}
+
+	public boolean isCancelled() {
+		return job.isDisposed();
+	}
+
+	public void cancel() {
+		job.dispose();
+	}
+}

--- a/src/test/java/io/oneko/docker/DockerRegistryPollingJobTest.java
+++ b/src/test/java/io/oneko/docker/DockerRegistryPollingJobTest.java
@@ -1,0 +1,48 @@
+package io.oneko.docker;
+
+import static com.google.common.truth.Truth.*;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.Test;
+
+import io.oneko.utils.TimeMachine;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+
+public class DockerRegistryPollingJobTest {
+
+	@Test
+	public void testJobShouldTimeout() {
+		TimeMachine timeMachine = new TimeMachine();
+		DockerRegistryPollingJob uut = new DockerRegistryPollingJob(Flux.empty().subscribe(), Instant.now()).withTimeoutDuration(Duration.ofMinutes(5));
+		uut.setClock(timeMachine);
+		assertThat(uut.shouldCancel()).isFalse();
+
+		timeMachine.timeTravelTo(timeMachine.instant().plus(Duration.ofMinutes(5)));
+		assertThat(uut.shouldCancel()).isTrue();
+	}
+
+	@Test
+	public void shouldBeDisposedIfUnderlyingStreamIsDisposed() {
+		EmitterProcessor flux = EmitterProcessor.create();
+
+		DockerRegistryPollingJob uut = new DockerRegistryPollingJob(flux.subscribe(), Instant.now());
+		assertThat(uut.isCancelled()).isFalse();
+
+		flux.onComplete();
+		assertThat(uut.isCancelled()).isTrue();
+	}
+
+	@Test
+	public void shouldBeCancellable() {
+		EmitterProcessor flux = EmitterProcessor.create();
+
+		DockerRegistryPollingJob uut = new DockerRegistryPollingJob(flux.subscribe(), Instant.now());
+		assertThat(uut.isCancelled()).isFalse();
+
+		uut.cancel();
+		assertThat(uut.isCancelled()).isTrue();
+	}
+}


### PR DESCRIPTION
The jobs will not time out after five minutes and should generally be more stable.

This addresses and closes #5. 