### PR TITLE
fix(performance): Replace svg icon spritesheet with lazy loaded svgs

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -46,5 +46,5 @@ Thumbs.db
 node
 
 # Generated Icon Stuff
-/src/app/configuration/mdi.ts
+/src/app/configuration/generated/*.ts
 /src/assets/icons/mdi/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -44,3 +44,7 @@ package-lock.json
 Thumbs.db
 
 node
+
+# Generated Icon Stuff
+/src/app/configuration/mdi.ts
+/src/assets/icons/mdi/

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -17,12 +17,7 @@
             "tsConfig": "src/tsconfig.app.json",
             "polyfills": "src/polyfills.ts",
             "assets": [
-              "src/assets",
-              {
-                "glob": "mdi.svg",
-                "input": "./node_modules/@mdi/angular-material/",
-                "output": "assets"
-              }
+              "src/assets"
             ],
             "styles": [
               "src/mat-theme.scss",
@@ -84,12 +79,7 @@
               "src/styles.scss"
             ],
             "assets": [
-              "src/assets",
-              {
-                "glob": "mdi.svg",
-                "input": "./node_modules/@mdi/angular-material/",
-                "output": "assets"
-              }
+              "src/assets"
             ]
           }
         },

--- a/frontend/extract-svg-icons.js
+++ b/frontend/extract-svg-icons.js
@@ -19,7 +19,7 @@ function writeSvgDefinitionFile(filePath, constName, basePath, iconNames) {
   let file =
     `// THIS FILE IS GENERATED AUTOMATICALLY BY extract-svg-icons.js
 // DO NOT EDIT IT MANUALLY - YOU WILL LOSE YOUR CHANGES
-import {IconSet} from './icon';
+import {IconSet} from '../icon';
 
 export const ${constName}: IconSet = {
   basePath: '${basePath}',
@@ -47,7 +47,7 @@ function extractMdiIconSet() {
   const iconNames = getSvgIconNamesFromDirectory('./node_modules/@mdi/svg/svg');
   fs.mkdirSync(`./src/assets/icons/mdi/`, {recursive: true});
   iconNames.forEach(iconName => fs.copyFileSync(`./node_modules/@mdi/svg/svg/${iconName}.svg`, `./src/assets/icons/mdi/${iconName}.svg`));
-  writeSvgDefinitionFile('./src/app/configuration/mdi.ts', 'MDI_SVG_ICONS', 'assets/icons/mdi', iconNames);
+  writeSvgDefinitionFile('./src/app/configuration/generated/mdi.ts', 'MDI_SVG_ICONS', 'assets/icons/mdi', iconNames);
 }
 
 extractMdiIconSet();

--- a/frontend/extract-svg-icons.js
+++ b/frontend/extract-svg-icons.js
@@ -1,0 +1,53 @@
+/**
+ * This script:
+ *
+ * 1. Copies the SVG files from the node module into our assets directory (in the case of @mdi/svg)
+ * 2. Generates a .ts file with a definition of the icon set. This definition contains a name of all available icons in
+ *    the icon set.
+ *
+ * The generated .ts file can be used to add every icon individually to Angular Material. This is more work now, but
+ * the result is that a user visiting our app will only download the icons we actually used in the frontend.
+ * This happens in the ./src/app/configuration/configuration.ts file.
+ *
+ * Without this script we would have to import a svg sprite sheet which contains all icons in a given icon set, and
+ * a user would download the whole icon set, even though we only use <=1% of the available icons there.
+ */
+
+const fs = require('fs');
+
+function writeSvgDefinitionFile(filePath, constName, basePath, iconNames) {
+  let file =
+    `// THIS FILE IS GENERATED AUTOMATICALLY BY extract-svg-icons.js
+// DO NOT EDIT IT MANUALLY - YOU WILL LOSE YOUR CHANGES
+import {IconSet} from './icon';
+
+export const ${constName}: IconSet = {
+  basePath: '${basePath}',
+  icons: [\n`;
+
+  for (let i = 0; i < iconNames.length; i++) {
+    file += `    '${iconNames[i]}'`;
+    if (i < iconNames.length - 1) {
+      file += `,\n`
+    }
+  }
+
+  file += `\n  ]\n};\n`;
+
+  fs.writeFileSync(filePath, new Uint8Array(Buffer.from(file)));
+}
+
+function getSvgIconNamesFromDirectory(path) {
+  return fs.readdirSync(path)
+    .filter(filename => filename.endsWith('.svg'))
+    .map(filename => filename.slice(0, -4));
+}
+
+function extractMdiIconSet() {
+  const iconNames = getSvgIconNamesFromDirectory('./node_modules/@mdi/svg/svg');
+  fs.mkdirSync(`./src/assets/icons/mdi/`, {recursive: true});
+  iconNames.forEach(iconName => fs.copyFileSync(`./node_modules/@mdi/svg/svg/${iconName}.svg`, `./src/assets/icons/mdi/${iconName}.svg`));
+  writeSvgDefinitionFile('./src/app/configuration/mdi.ts', 'MDI_SVG_ICONS', 'assets/icons/mdi', iconNames);
+}
+
+extractMdiIconSet();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "ng build --prod && gzipper --level 9 ./dist",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "postinstall": "node extract-svg-icons.js"
   },
   "private": true,
   "dependencies": {
@@ -23,7 +24,7 @@
     "@angular/platform-browser": "8.2.9",
     "@angular/platform-browser-dynamic": "8.2.9",
     "@angular/router": "8.2.9",
-    "@mdi/angular-material": "4.4.95",
+    "@mdi/svg": "5.2.45",
     "core-js": "2.6.5",
     "hammerjs": "2.0.8",
     "hash-it": "4.0.4",

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -96,6 +96,7 @@ import {MustMatchValidatorDirective} from "./util/validators/must-match.validato
 import {UsernameAvailableValidator} from "./util/validators/username-available.validator";
 import {WebSocketServiceWrapper} from "./websocket/web-socket-service-wrapper.service";
 import {WebSocketService} from "./websocket/web-socket.service";
+import {configureSvgIcons} from "./configuration/configuration";
 
 @NgModule({
   declarations: [
@@ -235,7 +236,7 @@ import {WebSocketService} from "./websocket/web-socket.service";
 })
 export class AppModule {
   constructor(matIconRegistry: MatIconRegistry, domSanitizer: DomSanitizer, rest: RestService, auth: AuthService, ws: WebSocketService) {
-    matIconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('assets/mdi.svg'));
+    configureSvgIcons(matIconRegistry, domSanitizer);
 
     auth.isAuthenticated().subscribe(authenticated => {
       if (authenticated) {

--- a/frontend/src/app/configuration/configuration.ts
+++ b/frontend/src/app/configuration/configuration.ts
@@ -1,0 +1,11 @@
+import {MatIconRegistry} from '@angular/material/icon';
+import {DomSanitizer} from '@angular/platform-browser';
+import {MDI_SVG_ICONS} from './mdi';
+
+export const configureSvgIcons = (iconRegistry: MatIconRegistry, domSanitizer: DomSanitizer) => {
+  // If the following produces errors in your IDE you need to install the npm dependencies
+  // or run the postinstall script (O-NEKO-ROOT/frontend/extract-svg-icons.js) manually via node
+  MDI_SVG_ICONS.icons.forEach(svgIcon => {
+    iconRegistry.addSvgIcon(svgIcon, domSanitizer.bypassSecurityTrustResourceUrl(`${MDI_SVG_ICONS.basePath}/${svgIcon}.svg`));
+  });
+};

--- a/frontend/src/app/configuration/configuration.ts
+++ b/frontend/src/app/configuration/configuration.ts
@@ -1,6 +1,6 @@
 import {MatIconRegistry} from '@angular/material/icon';
 import {DomSanitizer} from '@angular/platform-browser';
-import {MDI_SVG_ICONS} from './mdi';
+import {MDI_SVG_ICONS} from './generated/mdi';
 
 export const configureSvgIcons = (iconRegistry: MatIconRegistry, domSanitizer: DomSanitizer) => {
   // If the following produces errors in your IDE you need to install the npm dependencies

--- a/frontend/src/app/configuration/icon.ts
+++ b/frontend/src/app/configuration/icon.ts
@@ -1,0 +1,5 @@
+export interface IconSet {
+ basePath: string;
+ icons: Array<string>;
+}
+


### PR DESCRIPTION
That way users won't have to download > 5000 icons while we're only using a handful.