### PR TITLE
feat(wakeup): templated URLs

### DIFF
--- a/docs/chapters/GETTING_STARTED.md
+++ b/docs/chapters/GETTING_STARTED.md
@@ -40,7 +40,25 @@ It's easiest to configure a project if you already have a working values .yaml f
 configuration template via the "..." menu to the right. Then select your Helm registry, the chart and (optionally) the
 chart version. Then you can write your Helm values .yaml file in the editor.
 
-### 6.1 Make the Helm values O-Neko compatible
+### 6.1 Configuring URLs via URL Templates
+
+Your projects probably host one or more web frontends which should be hosted under one or more URLs. You will want every
+version to get its own domain. You can add URL templates to a project, which will be available in the following configuration.
+Versions can extend the list of URL templates but always inherit the URLs of their project.
+
+In most cases a simple URL template consisting of a string that contains the variable `{{ SAFE_VERSION_NAME }}` 
+will be sufficient to cover your needs. The URL template may look like this and will be available in the following configuration
+as the array-variable `URLS`:
+
+```yaml
+my_app-{{ SAFE_VERSION_NAME }}.my-k8s-cluster.my-company.com
+```
+
+This URL will be available in the following templates as `URLS[0]`. If you add more URLs you'll reference them with a
+different index. After defining the URLs here you will have to reference them in the following configuration, for example
+to configure an ingress etc.
+
+### 6.2 Make the Helm values O-Neko compatible
 
 In order to deploy everything correctly, you need to replace some fixed entries in your files with a template variable syntax.
 The most important is the docker image tag in your deployment.
@@ -55,11 +73,11 @@ your cluster to re-deploy a version but the cluster will not pull an updated ima
 the cluster to pull your image every time. If your Helm chart does not allow to change the `imagePullPolicy` you need to
 extend your Helm chart.
 
-In order to get dynamic URLs to your app you'll have to configure the host name (e.g. in an ingress).
-In this template you should replace the host string with a string that contains the variable `{{SAFE_VERSION_NAME}}`, like this:
+In order to get dynamic URLs to your app you'll have to configure the host name (e.g. in an ingress). In this template 
+you should replace the host string with one of your configured URLs (as explained above), e.g.:
 
 ```yaml
-- host: my_app-{{SAFE_VERSION_NAME}}.my-k8s-cluster.my-company.com
+- host: {{ URLS[0] }}
 ```
 
 `SAFE_VERSION_NAME` should be used, because this will make sure that the string replaced there will result in a valid URL.
@@ -71,10 +89,11 @@ There are some other default template variables you can use:
 * `VERSION_NAME` (the name of a version; the docker image tag)
 * `SAFE_VERSION_NAME` (the URL compatible version name)
 * `ONEKO_VERSION` (the version's ID)
+* `URLS` (the URL(s) of your deployment - this is always an array, see the section about URLs)
 
 You can also create your own template variables and override them in specific versions as you like.
 
-### 6.2 Control the lifetime of a deployed version
+### 6.3 Control the lifetime of a deployed version
 
 You can control when new versions should be updated or stopped. In most cases the defaults should be fine. Choose something that
 fits for most of your versions. You can still override these settings for specific long-running versions (e.g. your `latest`) version.

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -117,6 +117,7 @@ import {DistinctObjectArrayPipe} from "./util/distinct-object-array.pipe";
 import {FilterDeepPipe} from "./util/filter-deep.pipe";
 import {I18nSwitcherComponent} from "./components/i18n-switcher/i18n-switcher.component";
 import {I18nState} from "./store/i18n/i18n.state";
+import {UrlTemplatesComponent} from "./form/url-templates-input/url-templates.component";
 
 @NgModule({
     declarations: [
@@ -175,7 +176,8 @@ import {I18nState} from "./store/i18n/i18n.state";
         HelmRegistryEditDialogComponent,
         DistinctObjectArrayPipe,
         FilterDeepPipe,
-        I18nSwitcherComponent
+        I18nSwitcherComponent,
+        UrlTemplatesComponent
     ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/deployable/template-editor/template-editor.html
+++ b/frontend/src/app/deployable/template-editor/template-editor.html
@@ -3,7 +3,7 @@
   <div>
     <div fxLayout="row" fxLayoutAlign="space-between center">
       <div *ngIf="!currentTemplateModel" fxLayout="row" fxLayoutAlign="space-between center">
-        <mat-icon svgIcon="mdi:information-outline" color="primary"></mat-icon>
+        <mat-icon svgIcon="mdi:information" color="primary"></mat-icon>
         <span class="create-template-info">{{'components.templateEditor.createTemplateHelpInfo' | translate}}</span>
       </div>
       <button mat-icon-button [matMenuTriggerFor]="menu" [matTooltip]="'general.options' | translate">
@@ -12,17 +12,17 @@
     </div>
     <mat-menu #menu="matMenu">
       <button mat-menu-item [disabled]="readonly" (click)="openEditConfigurationTemplateDialog(currentTemplateModel)">
-        <mat-icon svgIcon="mdi:pencil-outline"></mat-icon>
+        <mat-icon svgIcon="mdi:pencil"></mat-icon>
         <span>{{'general.rename' | translate}}</span>
       </button>
       <hr />
       <button mat-menu-item [disabled]="readonly" (click)="onAddNewTemplate()">
-        <mat-icon svgIcon="mdi:plus-outline"></mat-icon>
+        <mat-icon svgIcon="mdi:plus"></mat-icon>
         <span>{{'components.templateEditor.createNewTemplate' | translate}}</span>
       </button>
       <file-upload [multiple]="true" (filesCallback)="onConfigUpload($event)" displayType="menu-item" [label]="'components.templateEditor.uploadYaml' | translate" [disabled]="readonly"></file-upload>
       <button mat-menu-item (click)="onDownloadCurrentFile(currentTemplateModel)">
-        <mat-icon svgIcon="mdi:download-outline"></mat-icon>
+        <mat-icon svgIcon="mdi:download"></mat-icon>
         <span>{{'components.templateEditor.downloadCurrentFile' | translate}}</span>
       </button>
     </mat-menu>
@@ -44,7 +44,7 @@
     <!-- Default Templates -->
     <mat-tab [label]="template.name" *ngFor="let template of configurationTemplatesModels; let i = index">
       <ng-template mat-tab-label>
-        <mat-icon [svgIcon]="template.isOriginal() ? 'mdi:file-outline' : 'mdi:file-document-outline'"></mat-icon>
+        <mat-icon [svgIcon]="template.isOriginal() ? 'mdi:file' : 'mdi:file-document'"></mat-icon>
         <span>{{template.name}}</span>
         <button *ngIf="template.isOriginal() && !readonly" mat-icon-button (click)="removeTemplateWithConfirmation(template)"><mat-icon svgIcon="mdi:close"></mat-icon></button>
         <button *ngIf="template.isOverwriting() && !readonly" mat-icon-button (click)="useDefaultProjectConfigurationTemplate(template)"><mat-icon svgIcon="mdi:undo-variant"></mat-icon></button>

--- a/frontend/src/app/form/upload/file-upload.component.html
+++ b/frontend/src/app/form/upload/file-upload.component.html
@@ -20,7 +20,7 @@
 </div>
 
 <button mat-menu-item [disabled]="disabled" *ngIf="displayType === 'menu-item'" (click)="!disabled && imageFileInput.click()">
-  <mat-icon svgIcon="mdi:upload-outline"></mat-icon>
+  <mat-icon svgIcon="mdi:upload"></mat-icon>
   <span>{{label}}</span>
 </button>
 

--- a/frontend/src/app/form/url-templates-input/url-templates.component.html
+++ b/frontend/src/app/form/url-templates-input/url-templates.component.html
@@ -1,0 +1,30 @@
+<div class="form-field-group">
+  <h4>{{ 'components.forms.urlTemplatesInput.urlTemplates' | translate }}</h4>
+
+  <div fxLayout="column">
+    <div fxLayout="row">
+        <mat-form-field fxFlex>
+          <input matInput #input="matInput" #inputModel="ngModel" [(ngModel)]="textInput" [placeholder]="'components.forms.urlTemplatesInput.addNewPlaceholder' | translate" [forbiddenValues]="urlTemplates" />
+        </mat-form-field>
+        <button mat-icon-button (click)="addUrl()" [disabled]="input.empty || inputModel.invalid && inputModel.errors.forbiddenValues" [matTooltip]="'general.add' | translate">
+          <mat-icon svgIcon="mdi:plus"></mat-icon>
+        </button>
+    </div>
+    <div *ngFor="let template of readOnlyTemplates; let index = index" fxLayout="row">
+      <mat-form-field fxFlex>
+        <input matInput disabled type="text" [name]="'ro_url_template_' + index" [value]="template"/>
+      </mat-form-field>
+      <button mat-icon-button disabled>
+        <mat-icon svgIcon="mdi:delete"></mat-icon>
+      </button>
+    </div>
+    <div *ngFor="let template of urlTemplates; let index = index" fxLayout="row">
+      <mat-form-field fxFlex>
+        <input matInput disabled type="text" [name]="'url_template_' + index" [value]="template"/>
+      </mat-form-field>
+      <button mat-icon-button (click)="deleteUrl(template)" [matTooltip]="'general.delete' | translate">
+        <mat-icon svgIcon="mdi:delete"></mat-icon>
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/form/url-templates-input/url-templates.component.scss
+++ b/frontend/src/app/form/url-templates-input/url-templates.component.scss
@@ -1,0 +1,4 @@
+
+input {
+  font-family: monospace;
+}

--- a/frontend/src/app/form/url-templates-input/url-templates.component.ts
+++ b/frontend/src/app/form/url-templates-input/url-templates.component.ts
@@ -1,0 +1,46 @@
+import {Component, EventEmitter, Input, OnInit, Output, ViewChild} from "@angular/core";
+import {MatInput} from "@angular/material/input";
+
+@Component({
+  selector: 'on-url-templates-input',
+  templateUrl: './url-templates.component.html',
+  styleUrls: ['./url-templates.component.scss']
+})
+export class UrlTemplatesComponent implements OnInit {
+
+  @Input("urlTemplates")
+  public _urlTemplates: Array<string> = [];
+  public urlTemplates: Array<string> = [];
+
+  @Input("readOnlyUrlTemplates")
+  public _readOnlyTemplates: Array<string> = [];
+  public readOnlyTemplates: Array<string> = [];
+
+  @Output()
+  public templatesChange = new EventEmitter<Array<string>>();
+
+  @ViewChild("input", {static: true})
+  public input: MatInput;
+  textInput: string;
+
+  ngOnInit(): void {
+    this.urlTemplates = Array.of(...this._urlTemplates);
+    this.readOnlyTemplates = Array.of(...this._readOnlyTemplates);
+  }
+
+  emitChanges(): void {
+    this.templatesChange.emit(this.urlTemplates);
+  }
+
+  deleteUrl(template: string) {
+    this.urlTemplates = this.urlTemplates.filter(tpl => tpl != template);
+    this.emitChanges();
+  }
+
+  public addUrl(): void {
+    this.urlTemplates.push(this.textInput);
+    this.input.value = "";
+    this.emitChanges();
+  }
+
+}

--- a/frontend/src/app/project/edit-version/edit-project-version.component.html
+++ b/frontend/src/app/project/edit-version/edit-project-version.component.html
@@ -30,6 +30,9 @@
               <mat-option *ngFor="let namespace of namespaces" [value]="namespace.name">{{namespace.name}}</mat-option>
             </mat-select>
           </mat-form-field>
+          <on-url-templates-input [urlTemplates]="projectVersion.urlTemplates"
+                                  [readOnlyUrlTemplates]="project.urlTemplates"
+                                  (templatesChange)="onUrlTemplatesChanged($event)"></on-url-templates-input>
 
           <div class="form-field-group">
             <template-editor [templates]="projectVersion.configurationTemplates"

--- a/frontend/src/app/project/edit-version/edit-project-version.component.ts
+++ b/frontend/src/app/project/edit-version/edit-project-version.component.ts
@@ -137,4 +137,8 @@ export class EditProjectVersionComponent implements OnInit, OnDestroy {
       this.projectVersion.templateVariables[event.key] = event.value;
     }
   }
+
+  onUrlTemplatesChanged(templates: Array<string>) {
+    this.projectVersion.urlTemplates = templates;
+  }
 }

--- a/frontend/src/app/project/edit/edit-project.component.html
+++ b/frontend/src/app/project/edit/edit-project.component.html
@@ -40,6 +40,8 @@
               <mat-option *ngFor="let namespace of namespaces" [value]="namespace.name">{{namespace.name}}</mat-option>
             </mat-select>
           </mat-form-field>
+          <on-url-templates-input [urlTemplates]="project.urlTemplates"
+                                  (templatesChange)="onUrlTemplatesChanged($event)"></on-url-templates-input>
 
           <div class="form-field-group">
             <template-editor [templates]="project.defaultConfigurationTemplates"

--- a/frontend/src/app/project/edit/edit-project.component.ts
+++ b/frontend/src/app/project/edit/edit-project.component.ts
@@ -95,4 +95,8 @@ export class EditProjectComponent implements OnInit {
       FileDownloadService.downloadJSON(projectExport, `${projectExport.name}.json`);
     });
   }
+
+  onUrlTemplatesChanged(templates: Array<string>) {
+    this.project.urlTemplates = templates;
+  }
 }

--- a/frontend/src/app/project/project-export.ts
+++ b/frontend/src/app/project/project-export.ts
@@ -24,6 +24,7 @@ export interface ProjectExportDTO {
   name: string;
   imageName: string;
   newVersionsDeploymentBehaviour: DeploymentBehaviour;
+  urlTemplates: Array<string>;
   defaultConfigurationTemplates: Array<ProjectExportConfigurationTemplate>;
   templateVariables: ProjectExportTemplateVariable[];
   dockerRegistryUUID?: string;

--- a/frontend/src/app/project/project-version.ts
+++ b/frontend/src/app/project/project-version.ts
@@ -12,6 +12,7 @@ export interface ProjectVersionDTO {
   availableTemplateVariables: TemplateVariable[];
   deployment: DeploymentDTO;
   urls: Array<string>;
+  urlTemplates: Array<string>;
   configurationTemplates: Array<ConfigurationTemplate>;
   outdated: boolean
   lifetimeBehaviour?: LifetimeBehaviour;
@@ -25,6 +26,7 @@ export class ProjectVersion implements ProjectVersionDTO {
   name: string;
   deploymentBehaviour: DeploymentBehaviour;
   templateVariables?: { [key: string]: string };
+  urlTemplates: Array<string>;
   availableTemplateVariables: TemplateVariable[];
   deployment: Deployment;
   urls: Array<string>;
@@ -49,6 +51,7 @@ export class ProjectVersion implements ProjectVersionDTO {
     version.name = from.name;
     version.deploymentBehaviour = from.deploymentBehaviour;
     version.templateVariables = cloneDeep(from.templateVariables);
+    version.urlTemplates = from.urlTemplates;
     version.availableTemplateVariables = cloneDeep(from.availableTemplateVariables);
     version.deployment = Deployment.from(from.deployment);
     version.urls = from.urls;
@@ -69,6 +72,7 @@ export class ProjectVersion implements ProjectVersionDTO {
     this.availableTemplateVariables = cloneDeep(from.availableTemplateVariables);
     this.deployment = Deployment.from(from.deployment);
     this.urls = from.urls;
+    this.urlTemplates = from.urlTemplates;
     this.configurationTemplates = from.configurationTemplates;
     this.outdated = from.outdated;
     this.lifetimeBehaviour = from.lifetimeBehaviour;

--- a/frontend/src/app/project/project.ts
+++ b/frontend/src/app/project/project.ts
@@ -17,6 +17,7 @@ export interface ProjectDTO {
   name?: string;
   imageName: string;
   newVersionsDeploymentBehaviour: DeploymentBehaviour;
+  urlTemplates: Array<string>;
   defaultConfigurationTemplates: Array<ConfigurationTemplate>;
   templateVariables: TemplateVariable[];
   dockerRegistryUUID?: string;
@@ -40,6 +41,7 @@ export class Project implements ProjectDTO {
   name?: string;
   imageName: string;
   newVersionsDeploymentBehaviour: DeploymentBehaviour;
+  urlTemplates: Array<string>;
   defaultConfigurationTemplates: Array<ConfigurationTemplate>;
   templateVariables: Array<TemplateVariable> = [];
   dockerRegistryUUID?: string;
@@ -57,6 +59,7 @@ export class Project implements ProjectDTO {
 
     project.imageName = from.imageName;
     project.newVersionsDeploymentBehaviour = from.newVersionsDeploymentBehaviour;
+    project.urlTemplates = from.urlTemplates || [];
     project.defaultConfigurationTemplates = from.defaultConfigurationTemplates.map(tpl => ConfigurationTemplate.from(tpl)) || [];
     project.templateVariables = from.templateVariables || [];
     project.dockerRegistryUUID = from.dockerRegistryUUID;
@@ -86,6 +89,7 @@ export class Project implements ProjectDTO {
     project.status = from.status;
     project.defaultLifetimeBehaviour = from.defaultLifetimeBehaviour;
 
+    project.urlTemplates = from.urlTemplates;
     // remove potentially existing ids
     project.defaultConfigurationTemplates = (from.defaultConfigurationTemplates as Array<ConfigurationTemplateDTO> ?? [])
       .map(({id, ...configurationTemplate}) => ConfigurationTemplate.from(configurationTemplate as ConfigurationTemplateDTO));

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -16,7 +16,8 @@
     "edit": "Bearbeiten",
     "viewDetails": "Details öffnen",
     "done": "Fertig",
-    "confirm": "Bestätigen"
+    "confirm": "Bestätigen",
+    "add": "Hinzufügen"
   },
   "menu": {
     "home": "Home",
@@ -159,6 +160,10 @@
         "weeks": "{count} {count, plural, one{Woche} other{Wochen}}",
         "infinite": "Unendlich",
         "hint": "Wählen Sie wie lang deployte Ressourcen nach ihrem letzten Deployment am Leben erhalten bleiben sollen."
+      },
+      "urlTemplatesInput": {
+        "urlTemplates": "URL Templates",
+        "addNewPlaceholder": "Geben Sie ein neues URL Template ein"
       },
       "fileUpload": {
         "dndFiles": "Ziehen Sie Dateien hier hin",

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -16,7 +16,8 @@
     "edit": "Edit",
     "viewDetails": "View details",
     "done": "Done",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "add": "Add"
   },
   "menu": {
     "home": "Home",
@@ -159,6 +160,10 @@
         "weeks": "{count} {count, plural, one{Week} other{Weeks}}",
         "infinite": "Infinite",
         "hint": "Choose how long deployed resources should be kept alive after their last deployment"
+      },
+      "urlTemplatesInput": {
+        "urlTemplates": "URL Templates",
+        "addNewPlaceholder": "Enter new URL template"
       },
       "fileUpload": {
         "dndFiles": "Drag and drop files here",

--- a/src/main/java/io/oneko/docker/event/DockerRegistrySavedEvent.java
+++ b/src/main/java/io/oneko/docker/event/DockerRegistrySavedEvent.java
@@ -20,7 +20,7 @@ public class DockerRegistrySavedEvent extends EntityChangedEvent {
 		super(DescribingEntityChange.builder()
 				.id(dockerRegistry.getUuid())
 				.name(dockerRegistry.getName())
-				.entityType(DescribingEntityChange.EntityType.HelmRegistry)
+				.entityType(DescribingEntityChange.EntityType.DockerRegistry)
 				.changeType(DescribingEntityChange.ChangeType.Saved)
 				.changedProperties(changedProperties)
 				.build());

--- a/src/main/java/io/oneko/kubernetes/impl/DeploymentManagerImpl.java
+++ b/src/main/java/io/oneko/kubernetes/impl/DeploymentManagerImpl.java
@@ -2,21 +2,14 @@ package io.oneko.kubernetes.impl;
 
 import static io.oneko.kubernetes.deployments.DesiredState.*;
 import static io.oneko.util.MoreStructuredArguments.*;
-import static net.logstash.logback.argument.StructuredArguments.*;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
-import io.fabric8.kubernetes.api.model.extensions.IngressRule;
 import io.oneko.docker.v2.DockerRegistryClientFactory;
 import io.oneko.docker.v2.model.manifest.Manifest;
 import io.oneko.helm.HelmRegistryException;
@@ -25,7 +18,6 @@ import io.oneko.helmapi.model.InstallStatus;
 import io.oneko.helmapi.model.Status;
 import io.oneko.kubernetes.DeploymentManager;
 import io.oneko.kubernetes.deployments.DeploymentRepository;
-import io.oneko.kubernetes.deployments.DesiredState;
 import io.oneko.kubernetes.deployments.ReadableDeployment;
 import io.oneko.kubernetes.deployments.WritableDeployment;
 import io.oneko.project.ProjectRepository;
@@ -39,16 +31,13 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 class DeploymentManagerImpl implements DeploymentManager {
 
-	private final KubernetesAccess kubernetesAccess;
 	private final DockerRegistryClientFactory dockerRegistryClientFactory;
 	private final ProjectRepository projectRepository;
 	private final DeploymentRepository deploymentRepository;
 
-	DeploymentManagerImpl(KubernetesAccess kubernetesAccess,
-												DockerRegistryClientFactory dockerRegistryClientFactory,
+	DeploymentManagerImpl(DockerRegistryClientFactory dockerRegistryClientFactory,
 												ProjectRepository projectRepository,
 												DeploymentRepository deploymentRepository) {
-		this.kubernetesAccess = kubernetesAccess;
 		this.dockerRegistryClientFactory = dockerRegistryClientFactory;
 		this.projectRepository = projectRepository;
 		this.deploymentRepository = deploymentRepository;
@@ -72,9 +61,9 @@ class DeploymentManagerImpl implements DeploymentManager {
 			deployment.setReleaseNames(releaseNames);
 			deploymentRepository.save(deployment);
 
-			final Set<HasMetadata> createdKubernetesResources = getTemplateAsResources(version);
-			version = updateDeployableWithCreatedResources(version, createdKubernetesResources);
+			version = updateDeployableWithCreatedResources(version);
 			version.setDesiredState(Deployed);
+
 			final ReadableProject project = projectRepository.add(version.getProject());
 			return project.getVersions().stream()
 					.filter(projectVersion -> projectVersion.getUuid().equals(versionId))
@@ -92,8 +81,7 @@ class DeploymentManagerImpl implements DeploymentManager {
 				.orElseGet(() -> WritableDeployment.getDefaultDeployment(projectVersion.getId()));
 	}
 
-	private WritableProjectVersion updateDeployableWithCreatedResources(WritableProjectVersion deployable, Set<HasMetadata> createdResources) {
-		updateDeploymentUrls(deployable, createdResources);
+	private WritableProjectVersion updateDeployableWithCreatedResources(WritableProjectVersion deployable) {
 		deployable.setOutdated(false);
 		if (!StringUtils.isEmpty(deployable.getDockerContentDigest())) {
 			return deployable;
@@ -107,49 +95,10 @@ class DeploymentManagerImpl implements DeploymentManager {
 				}).orElse(null);
 	}
 
-	private Set<HasMetadata> getTemplateAsResources(ProjectVersion<?, ?> deployable) {
-		Set<HasMetadata> resources = new HashSet<>();
-		HelmCommandUtils.getKubernetesYamlResources(deployable).forEach(template -> resources.addAll(kubernetesAccess.loadResource(template)));
-		return resources;
-	}
-
-	private void updateDeploymentUrls(WritableProjectVersion projectVersion, Set<HasMetadata> createdResources) {
-		List<String> urls = createdResources.stream()
-				.flatMap(hasMetadata -> {
-					if (hasMetadata instanceof Ingress) {
-						var ingress = (Ingress) hasMetadata;
-						return ingress
-								.getSpec()
-								.getRules()
-								.stream()
-								.map(IngressRule::getHost);
-					} else if (hasMetadata instanceof io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress) {
-						var ingress = (io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress) hasMetadata;
-						return ingress
-								.getSpec()
-								.getRules()
-								.stream()
-								.map(io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule::getHost);
-					} else if (hasMetadata instanceof io.fabric8.kubernetes.api.model.networking.v1.Ingress) {
-						var ingress = (io.fabric8.kubernetes.api.model.networking.v1.Ingress) hasMetadata;
-						return ingress
-								.getSpec()
-								.getRules()
-								.stream()
-								.map(io.fabric8.kubernetes.api.model.networking.v1.IngressRule::getHost);
-					}
-					return Stream.empty();
-				}).collect(Collectors.toList());
-
-		log.trace("found deployment urls ({}, {})", versionKv(projectVersion), kv("urls", urls));
-		projectVersion.setUrls(urls);
-	}
-
 	@Override
 	public ReadableProjectVersion stopDeployment(WritableProjectVersion version) {
 		try {
 			HelmCommandUtils.uninstall(version);
-			version.setUrls(List.of());
 			version.setDesiredState(NotDeployed);
 			final ReadableProject readableProject = projectRepository.add(version.getProject());
 			return readableProject.getVersions().stream()

--- a/src/main/java/io/oneko/project/Project.java
+++ b/src/main/java/io/oneko/project/Project.java
@@ -24,6 +24,8 @@ public interface Project<P extends Project<P, V>, V extends ProjectVersion<P, V>
 
 	DeploymentBehaviour getNewVersionsDeploymentBehaviour();
 
+	List<String> getUrlTemplates();
+
 	List<? extends ConfigurationTemplate> getDefaultConfigurationTemplates();
 
 	List<? extends TemplateVariable> getTemplateVariables();

--- a/src/main/java/io/oneko/project/ProjectConstants.java
+++ b/src/main/java/io/oneko/project/ProjectConstants.java
@@ -13,6 +13,7 @@ public class ProjectConstants {
 		public static final String ONEKO_PROJECT = "ONEKO_PROJECT";
 		public static final String ONEKO_VERSION = "ONEKO_VERSION";
 		public static final String SAFE_VERSION_NAME = "SAFE_VERSION_NAME";
+		public static final String URLS = "URLS";
 	}
 
 	public static final class LabelNames {

--- a/src/main/java/io/oneko/project/ProjectVersion.java
+++ b/src/main/java/io/oneko/project/ProjectVersion.java
@@ -91,7 +91,9 @@ public interface ProjectVersion<P extends Project<P, V>, V extends ProjectVersio
 		implicitTemplateVariables.forEach(context::set);
 		context.set("fn", TemplateFunctions.class);
 		List<String> urlTemplates = new ArrayList<>();
-		urlTemplates.addAll(getProject().getUrlTemplates());
+		if (getProject() != null) {
+			urlTemplates.addAll(getProject().getUrlTemplates());
+		}
 		urlTemplates.addAll(getUrlTemplates());
 		return urlTemplates.stream()
 				.map(url -> {

--- a/src/main/java/io/oneko/project/ProjectVersion.java
+++ b/src/main/java/io/oneko/project/ProjectVersion.java
@@ -1,6 +1,7 @@
 package io.oneko.project;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,12 +90,9 @@ public interface ProjectVersion<P extends Project<P, V>, V extends ProjectVersio
 		TemplateContext context = new TemplateContext();
 		implicitTemplateVariables.forEach(context::set);
 		context.set("fn", TemplateFunctions.class);
-		List<String> urlTemplates;
-		if (!getUrlTemplates().isEmpty()) {
-			urlTemplates = getUrlTemplates();
-		} else {
-			urlTemplates = getProject().getUrlTemplates();
-		}
+		List<String> urlTemplates = new ArrayList<>();
+		urlTemplates.addAll(getProject().getUrlTemplates());
+		urlTemplates.addAll(getUrlTemplates());
 		return urlTemplates.stream()
 				.map(url -> {
 					TemplateLoader.MapTemplateLoader loader = new TemplateLoader.MapTemplateLoader();

--- a/src/main/java/io/oneko/project/ProjectVersion.java
+++ b/src/main/java/io/oneko/project/ProjectVersion.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringSubstitutor;
 
 import io.marioslab.basis.template.Template;
 import io.marioslab.basis.template.TemplateContext;
@@ -49,6 +48,8 @@ public interface ProjectVersion<P extends Project<P, V>, V extends ProjectVersio
 
 	List<String> getUrls();
 
+	List<String> getUrlTemplates();
+
 	List<? extends ConfigurationTemplate> getConfigurationTemplates();
 
 	boolean isOutdated();
@@ -83,20 +84,41 @@ public interface ProjectVersion<P extends Project<P, V>, V extends ProjectVersio
 		return safeName.substring(0, Math.min(safeName.length(), 63));
 	}
 
+	default String[] getCalculatedUrls() {
+		final Map<String, String> implicitTemplateVariables = getImplicitTemplateVariables();
+		TemplateContext context = new TemplateContext();
+		implicitTemplateVariables.forEach(context::set);
+		context.set("fn", TemplateFunctions.class);
+		List<String> urlTemplates;
+		if (!getUrlTemplates().isEmpty()) {
+			urlTemplates = getUrlTemplates();
+		} else {
+			urlTemplates = getProject().getUrlTemplates();
+		}
+		return urlTemplates.stream()
+				.map(url -> {
+					TemplateLoader.MapTemplateLoader loader = new TemplateLoader.MapTemplateLoader();
+					loader.set("tpl", url);
+					final Template tpl = loader.load("tpl");
+					return tpl.render(context);
+				}).toArray(String[]::new);
+	}
+
 	/**
 	 * Provides a mutable copy of all template variables retrieved by merging the ones from this version's
 	 * {@link #getProject()} and this version's own {@link #getTemplateVariables()}.
 	 *
 	 * @return Never <code>null</code>
 	 */
-	default Map<String, String> calculateEffectiveTemplateVariables() {
-		Map<String, String> mergedTemplateVariables = new HashMap<>();
+	default Map<String, Object> calculateEffectiveTemplateVariables() {
+		Map<String, Object> mergedTemplateVariables = new HashMap<>();
 
 		getProject().getTemplateVariables().
 				forEach(var -> mergedTemplateVariables.put(var.getName(), var.getDefaultValue()));
 		mergedTemplateVariables.putAll(getProject().getImplicitTemplateVariables());
 		mergedTemplateVariables.putAll(getImplicitTemplateVariables());
 		mergedTemplateVariables.putAll(getTemplateVariables());
+		mergedTemplateVariables.put(ProjectConstants.TemplateVariablesNames.URLS, getCalculatedUrls());
 
 		return mergedTemplateVariables;
 	}
@@ -116,7 +138,7 @@ public interface ProjectVersion<P extends Project<P, V>, V extends ProjectVersio
 	 * template or a modified version template and the effective template variables.
 	 */
 	default List<WritableConfigurationTemplate> getCalculatedConfigurationTemplates() {
-		final Map<String, String> variables = this.calculateEffectiveTemplateVariables();
+		final Map<String, Object> variables = this.calculateEffectiveTemplateVariables();
 		//somehow java does not properly figure out the list type here
 		final List<ConfigurationTemplate> unifiedTemplates = ConfigurationTemplates.unifyTemplateSets(getProject().getDefaultConfigurationTemplates(), getConfigurationTemplates());
 

--- a/src/main/java/io/oneko/project/ReadableProject.java
+++ b/src/main/java/io/oneko/project/ReadableProject.java
@@ -10,8 +10,6 @@ import com.google.common.collect.ImmutableList;
 import io.oneko.automations.LifetimeBehaviour;
 import io.oneko.deployable.DeploymentBehaviour;
 import io.oneko.domain.Identifiable;
-import io.oneko.namespace.Namespace;
-import io.oneko.namespace.ReadableNamespace;
 import io.oneko.templates.ReadableConfigurationTemplate;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,19 +24,22 @@ public class ReadableProject extends Identifiable implements Project<ReadablePro
 	private final ImmutableList<ReadableConfigurationTemplate> defaultConfigurationTemplates;
 	private final UUID dockerRegistryId;
 	private final LifetimeBehaviour defaultLifetimeBehaviour;
+	private final ImmutableList<String> urlTemplates;
 	private final ImmutableList<ReadableTemplateVariable> templateVariables;
 	private final ImmutableList<ReadableProjectVersion> versions;
 	private final String namespace;
 
 	@Builder
 	public ReadableProject(UUID id, String name, String imageName, DeploymentBehaviour newVersionsDeploymentBehaviour,
-						   List<ReadableConfigurationTemplate> defaultConfigurationTemplates,
-						   UUID dockerRegistryId, LifetimeBehaviour defaultLifetimeBehaviour,
-						   List<ReadableTemplateVariable> templateVariables, List<ReadableProjectVersion> versions, String namespace) {
+												 List<ReadableConfigurationTemplate> defaultConfigurationTemplates,
+												 UUID dockerRegistryId, LifetimeBehaviour defaultLifetimeBehaviour,
+												 List<String> urlTemplates,
+												 List<ReadableTemplateVariable> templateVariables, List<ReadableProjectVersion> versions, String namespace) {
 		this.id = id;
 		this.name = name;
 		this.imageName = imageName;
 		this.newVersionsDeploymentBehaviour = newVersionsDeploymentBehaviour;
+		this.urlTemplates = urlTemplates == null ? ImmutableList.of() : ImmutableList.copyOf(urlTemplates);
 		this.defaultConfigurationTemplates = defaultConfigurationTemplates == null ? ImmutableList.of() : ImmutableList.copyOf(defaultConfigurationTemplates);
 		this.dockerRegistryId = dockerRegistryId;
 		this.defaultLifetimeBehaviour = defaultLifetimeBehaviour;
@@ -71,14 +72,15 @@ public class ReadableProject extends Identifiable implements Project<ReadablePro
 				.name(getName())
 				.imageName(getImageName())
 				.newVersionsDeploymentBehaviour(getNewVersionsDeploymentBehaviour())
+				.urlTemplates(getUrlTemplates())
 				.defaultConfigurationTemplates(getDefaultConfigurationTemplates().stream()
-					.map(ReadableConfigurationTemplate::writable)
-					.collect(Collectors.toList()))
+						.map(ReadableConfigurationTemplate::writable)
+						.collect(Collectors.toList()))
 				.dockerRegistryId(getDockerRegistryId())
 				.defaultLifetimeBehaviour(defaultLifetimeBehaviour)
 				.templateVariables(getTemplateVariables().stream()
-					.map(ReadableTemplateVariable::writable)
-					.collect(Collectors.toList()))
+						.map(ReadableTemplateVariable::writable)
+						.collect(Collectors.toList()))
 				.versions(versions)
 				.namespace(getNamespace())
 				.build();

--- a/src/main/java/io/oneko/project/ReadableProjectVersion.java
+++ b/src/main/java/io/oneko/project/ReadableProjectVersion.java
@@ -18,7 +18,6 @@ import io.oneko.automations.LifetimeBehaviour;
 import io.oneko.deployable.DeploymentBehaviour;
 import io.oneko.domain.Identifiable;
 import io.oneko.kubernetes.deployments.DesiredState;
-import io.oneko.namespace.Namespace;
 import io.oneko.templates.ReadableConfigurationTemplate;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +31,7 @@ public class ReadableProjectVersion extends Identifiable implements ProjectVersi
 	private final DeploymentBehaviour deploymentBehaviour;
 	private final ImmutableMap<String, String> templateVariables;
 	private final String dockerContentDigest;
+	private final ImmutableList<String> urlTemplates;
 	private final ImmutableList<String> urls;
 	private final ImmutableList<ReadableConfigurationTemplate> configurationTemplates;
 	private final boolean outdated;
@@ -42,9 +42,10 @@ public class ReadableProjectVersion extends Identifiable implements ProjectVersi
 
 	@Builder
 	public ReadableProjectVersion(UUID uuid, String name, DeploymentBehaviour deploymentBehaviour,
-								  Map<String, String> templateVariables, String dockerContentDigest, List<String> urls,
-								  List<ReadableConfigurationTemplate> configurationTemplates, boolean outdated, LifetimeBehaviour lifetimeBehaviour,
-								  String namespace, DesiredState desiredState, Instant imageUpdatedDate) {
+																Map<String, String> templateVariables, String dockerContentDigest, List<String> urls,
+																List<String> urlTemplates, List<ReadableConfigurationTemplate> configurationTemplates,
+																boolean outdated, LifetimeBehaviour lifetimeBehaviour, String namespace,
+																DesiredState desiredState, Instant imageUpdatedDate) {
 		this.uuid = uuid;
 		this.name = name;
 		this.deploymentBehaviour = deploymentBehaviour;
@@ -52,6 +53,7 @@ public class ReadableProjectVersion extends Identifiable implements ProjectVersi
 		this.templateVariables = templateVariables == null ? ImmutableMap.of() : ImmutableMap.copyOf(templateVariables);
 		this.urls = ImmutableList.copyOf(urls);
 		this.outdated = outdated;
+		this.urlTemplates = urlTemplates == null ? ImmutableList.of() : ImmutableList.copyOf(urlTemplates);
 		this.configurationTemplates = configurationTemplates == null ? ImmutableList.of() : ImmutableList.copyOf(configurationTemplates);
 		this.lifetimeBehaviour = lifetimeBehaviour;
 		this.namespace = namespace;
@@ -86,9 +88,10 @@ public class ReadableProjectVersion extends Identifiable implements ProjectVersi
 				.templateVariables(getTemplateVariables())
 				.dockerContentDigest(getDockerContentDigest())
 				.urls(getUrls())
+				.urlTemplates(getUrlTemplates())
 				.configurationTemplates(getConfigurationTemplates().stream()
-					.map(ReadableConfigurationTemplate::writable)
-					.collect(Collectors.toList()))
+						.map(ReadableConfigurationTemplate::writable)
+						.collect(Collectors.toList()))
 				.outdated(isOutdated())
 				.lifetimeBehaviour(lifetimeBehaviour)
 				.namespace(getNamespace())

--- a/src/main/java/io/oneko/project/WritableProject.java
+++ b/src/main/java/io/oneko/project/WritableProject.java
@@ -135,6 +135,11 @@ public class WritableProject extends ModificationAwareIdentifiable implements Pr
 
 	public void setUrlTemplates(List<String> urlTemplates) {
 		this.urlTemplates.set(urlTemplates);
+		updateUrlsOfAllVersions();
+	}
+
+	private void updateUrlsOfAllVersions() {
+		this.versions.forEach(WritableProjectVersion::setUrlsFromUrlTemplates);
 	}
 
 	public List<WritableConfigurationTemplate> getDefaultConfigurationTemplates() {

--- a/src/main/java/io/oneko/project/WritableProject.java
+++ b/src/main/java/io/oneko/project/WritableProject.java
@@ -37,6 +37,7 @@ public class WritableProject extends ModificationAwareIdentifiable implements Pr
 	private final ModificationAwareProperty<String> name = new ModificationAwareProperty<>(this, "name");
 	private final ModificationAwareProperty<String> imageName = new ModificationAwareProperty<>(this, "imageName");
 	private final ModificationAwareProperty<DeploymentBehaviour> newVersionsDeploymentBehaviour = new ModificationAwareProperty<>(this, "newVersionsDeploymentBehaviour");
+	private final ModificationAwareProperty<List<String>> urlTemplates = new ModificationAwareListProperty<>(this, "urlTemplates");
 	/**
 	 * Default configuration template to be used for versions. Should be a multi line yaml-string.
 	 */
@@ -66,12 +67,13 @@ public class WritableProject extends ModificationAwareIdentifiable implements Pr
 	 */
 	@Builder
 	public WritableProject(UUID id, String name, String imageName, DeploymentBehaviour newVersionsDeploymentBehaviour,
-						   List<WritableConfigurationTemplate> defaultConfigurationTemplates, List<WritableTemplateVariable> templateVariables,
-						   UUID dockerRegistryId, List<WritableProjectVersion> versions, LifetimeBehaviour defaultLifetimeBehaviour, String namespace) {
+												 List<String> urlTemplates, List<WritableConfigurationTemplate> defaultConfigurationTemplates, List<WritableTemplateVariable> templateVariables,
+												 UUID dockerRegistryId, List<WritableProjectVersion> versions, LifetimeBehaviour defaultLifetimeBehaviour, String namespace) {
 		this.id.init(id);
 		this.name.init(name);
 		this.imageName.init(imageName);
 		this.newVersionsDeploymentBehaviour.init(newVersionsDeploymentBehaviour);
+		this.urlTemplates.init(urlTemplates);
 		this.defaultConfigurationTemplates.init(defaultConfigurationTemplates);
 		this.dockerRegistryId.init(dockerRegistryId);
 		this.defaultLifetimeBehaviour.init(defaultLifetimeBehaviour);
@@ -125,6 +127,14 @@ public class WritableProject extends ModificationAwareIdentifiable implements Pr
 
 	public void setNewVersionsDeploymentBehaviour(DeploymentBehaviour newVersionsDeploymentBehaviour) {
 		this.newVersionsDeploymentBehaviour.set(newVersionsDeploymentBehaviour);
+	}
+
+	public List<String> getUrlTemplates() {
+		return urlTemplates.get();
+	}
+
+	public void setUrlTemplates(List<String> urlTemplates) {
+		this.urlTemplates.set(urlTemplates);
 	}
 
 	public List<WritableConfigurationTemplate> getDefaultConfigurationTemplates() {
@@ -226,6 +236,7 @@ public class WritableProject extends ModificationAwareIdentifiable implements Pr
 				.name(getName())
 				.imageName(getImageName())
 				.newVersionsDeploymentBehaviour(getNewVersionsDeploymentBehaviour())
+				.urlTemplates(getUrlTemplates())
 				.defaultConfigurationTemplates(getDefaultConfigurationTemplates().stream()
 						.map(WritableConfigurationTemplate::readable)
 						.collect(Collectors.toList()))

--- a/src/main/java/io/oneko/project/WritableProjectVersion.java
+++ b/src/main/java/io/oneko/project/WritableProjectVersion.java
@@ -35,6 +35,7 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 	private final ModificationAwareProperty<Map<String, String>> templateVariables = new ModificationAwareMapProperty<>(this, "templateVariables");
 	private final ModificationAwareProperty<String> dockerContentDigest = new ModificationAwareProperty<>(this, "dockerContentDigest");
 	private final ModificationAwareProperty<List<String>> urls = new ModificationAwareListProperty<>(this, "urls");
+	private final ModificationAwareProperty<List<String>> urlTemplates = new ModificationAwareListProperty<>(this, "urlTemplates");
 	private final ModificationAwareProperty<List<WritableConfigurationTemplate>> configurationTemplates = new ModificationAwareListProperty<>(this, "configurationTemplates");
 	private final ModificationAwareProperty<Boolean> outdated = new ModificationAwareProperty<>(this, "outdated");
 	private final ModificationAwareProperty<LifetimeBehaviour> lifetimeBehaviour = new ModificationAwareProperty<>(this, "lifetimeBehaviour");
@@ -44,9 +45,10 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 
 	@Builder
 	public WritableProjectVersion(UUID uuid, String name, DeploymentBehaviour deploymentBehaviour,
-	                              Map<String, String> templateVariables, String dockerContentDigest, List<String> urls,
-	                              List<WritableConfigurationTemplate> configurationTemplates, boolean outdated, LifetimeBehaviour lifetimeBehaviour,
-																String namespace, DesiredState desiredState, Instant imageUpdatedDate) {
+																Map<String, String> templateVariables, String dockerContentDigest, List<String> urls,
+																List<String> urlTemplates, List<WritableConfigurationTemplate> configurationTemplates,
+																boolean outdated, LifetimeBehaviour lifetimeBehaviour, String namespace,
+																DesiredState desiredState, Instant imageUpdatedDate) {
 		this.uuid.init(uuid);
 		this.name.init(name);
 		this.deploymentBehaviour.init(deploymentBehaviour);
@@ -54,6 +56,7 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 		this.templateVariables.init(templateVariables);
 		this.urls.init(urls);
 		this.outdated.init(outdated);
+		this.urlTemplates.init(urlTemplates);
 		this.configurationTemplates.init(configurationTemplates);
 		this.lifetimeBehaviour.init(lifetimeBehaviour);
 		this.namespace.init(namespace);
@@ -134,6 +137,15 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 		this.urls.set(urls);
 	}
 
+	@Override
+	public List<String> getUrlTemplates() {
+		return urlTemplates.get();
+	}
+
+	public void setUrlTemplates(List<String> urlTemplates) {
+		this.urlTemplates.set(urlTemplates);
+	}
+
 	public List<WritableConfigurationTemplate> getConfigurationTemplates() {
 		return this.configurationTemplates.get();
 	}
@@ -207,6 +219,7 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 				.templateVariables(getTemplateVariables())
 				.dockerContentDigest(getDockerContentDigest())
 				.urls(getUrls())
+				.urlTemplates(getUrlTemplates())
 				.configurationTemplates(getConfigurationTemplates().stream()
 						.map(WritableConfigurationTemplate::readable)
 						.collect(Collectors.toList()))

--- a/src/main/java/io/oneko/project/WritableProjectVersion.java
+++ b/src/main/java/io/oneko/project/WritableProjectVersion.java
@@ -3,6 +3,7 @@ package io.oneko.project;
 import static io.oneko.kubernetes.deployments.DesiredState.*;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,7 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 		this.urls.init(urls);
 		this.outdated.init(outdated);
 		this.urlTemplates.init(urlTemplates);
+		initUrlsFromUrlTemplates();
 		this.configurationTemplates.init(configurationTemplates);
 		this.lifetimeBehaviour.init(lifetimeBehaviour);
 		this.namespace.init(namespace);
@@ -69,6 +71,7 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 	 */
 	void setProject(WritableProject project) {
 		this.project = project;
+		initUrlsFromUrlTemplates();
 	}
 
 	/**
@@ -133,10 +136,6 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 		return urls.get();
 	}
 
-	public void setUrls(List<String> urls) {
-		this.urls.set(urls);
-	}
-
 	@Override
 	public List<String> getUrlTemplates() {
 		return urlTemplates.get();
@@ -144,6 +143,15 @@ public class WritableProjectVersion extends ModificationAwareIdentifiable implem
 
 	public void setUrlTemplates(List<String> urlTemplates) {
 		this.urlTemplates.set(urlTemplates);
+		setUrlsFromUrlTemplates();
+	}
+
+	public void initUrlsFromUrlTemplates() {
+		this.urls.init(Arrays.asList(getCalculatedUrls()));
+	}
+
+	void setUrlsFromUrlTemplates() {
+		this.urls.set(Arrays.asList(getCalculatedUrls()));
 	}
 
 	public List<WritableConfigurationTemplate> getConfigurationTemplates() {

--- a/src/main/java/io/oneko/project/persistence/ProjectMongo.java
+++ b/src/main/java/io/oneko/project/persistence/ProjectMongo.java
@@ -26,6 +26,7 @@ class ProjectMongo {
 	private String name;
 	private String imageName;
 	private DeploymentBehaviour newVersionsDeploymentBehaviour;
+	private List<String> urlTemplates;
 	private List<ConfigurationTemplateMongo> defaultConfigurationTemplates;
 	@Indexed
 	private UUID dockerRegistryUUID;

--- a/src/main/java/io/oneko/project/persistence/ProjectMongoRepository.java
+++ b/src/main/java/io/oneko/project/persistence/ProjectMongoRepository.java
@@ -94,6 +94,7 @@ class ProjectMongoRepository extends EventAwareProjectRepository {
 		projectMongo.setName(project.getName());
 		projectMongo.setImageName(project.getImageName());
 		projectMongo.setNewVersionsDeploymentBehaviour(project.getNewVersionsDeploymentBehaviour());
+		projectMongo.setUrlTemplates(project.getUrlTemplates());
 		projectMongo.setDefaultConfigurationTemplates(ConfigurationTemplateMongoMapper.toConfigurationTemplateMongos(project.getDefaultConfigurationTemplates()));
 		projectMongo.setTemplateVariables(this.toTemplateVariablesMongo(project.getTemplateVariables()));
 		projectMongo.setNamespace(project.getNamespace());
@@ -156,6 +157,7 @@ class ProjectMongoRepository extends EventAwareProjectRepository {
 		versionMongo.setDockerContentDigest(version.getDockerContentDigest());
 		versionMongo.setUrls(version.getUrls());
 		versionMongo.setOutdated(version.isOutdated());
+		versionMongo.setUrlTemplates(version.getUrlTemplates());
 		versionMongo.setConfigurationTemplates(ConfigurationTemplateMongoMapper.toConfigurationTemplateMongos(version.getConfigurationTemplates()));
 		versionMongo.setLifetimeBehaviour(version.getLifetimeBehaviour().orElse(null));
 		versionMongo.setNamespace(version.getNamespace());
@@ -177,6 +179,7 @@ class ProjectMongoRepository extends EventAwareProjectRepository {
 				.name(projectMongo.getName())
 				.imageName(projectMongo.getImageName())
 				.newVersionsDeploymentBehaviour(projectMongo.getNewVersionsDeploymentBehaviour())
+				.urlTemplates(projectMongo.getUrlTemplates())
 				.defaultConfigurationTemplates(ConfigurationTemplateMongoMapper.fromConfigurationTemplateMongos(projectMongo.getDefaultConfigurationTemplates()))
 				.templateVariables(fromTemplateVariablesMongo(projectMongo.getTemplateVariables()))
 				.dockerRegistryId(projectMongo.getDockerRegistryUUID())
@@ -195,6 +198,7 @@ class ProjectMongoRepository extends EventAwareProjectRepository {
 				.dockerContentDigest(versionMongo.getDockerContentDigest())
 				.urls(versionMongo.getUrls())
 				.outdated(versionMongo.isOutdated())
+				.urlTemplates(versionMongo.getUrlTemplates())
 				.configurationTemplates(ConfigurationTemplateMongoMapper.fromConfigurationTemplateMongos(versionMongo.getConfigurationTemplates()))
 				.lifetimeBehaviour(versionMongo.getLifetimeBehaviour())
 				.desiredState(versionMongo.getDesiredState())

--- a/src/main/java/io/oneko/project/persistence/ProjectVersionMongo.java
+++ b/src/main/java/io/oneko/project/persistence/ProjectVersionMongo.java
@@ -28,6 +28,7 @@ public class ProjectVersionMongo {
 	private DeploymentBehaviour deploymentBehaviour;
 	private String dockerContentDigest;
 	private List<String> urls;
+	private List<String> urlTemplates;
 	private List<ConfigurationTemplateMongo> configurationTemplates;
 	private boolean outdated;
 	private LifetimeBehaviour lifetimeBehaviour;

--- a/src/main/java/io/oneko/project/rest/DeployableConfigurationDTOMapper.java
+++ b/src/main/java/io/oneko/project/rest/DeployableConfigurationDTOMapper.java
@@ -1,6 +1,8 @@
 package io.oneko.project.rest;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +30,18 @@ public class DeployableConfigurationDTOMapper {
 		DeployableConfigurationDTO dto = new DeployableConfigurationDTO();
 		dto.setName(version.getName());
 		dto.setConfigurationTemplates(templateDTOs);
-		dto.setAvailableTemplateVariables(version.calculateEffectiveTemplateVariables());
+		Map<String, String> effectiveTemplateVariables = new HashMap<>();
+		for (Map.Entry<String, Object> entry : version.calculateEffectiveTemplateVariables().entrySet()) {
+			if (entry.getValue() instanceof String) {
+				effectiveTemplateVariables.put(entry.getKey(), (String) entry.getValue());
+			} else if (entry.getValue() instanceof String[]) {
+				String[] arr = (String[]) entry.getValue();
+				for (int i = 0; i < arr.length; i++) {
+					effectiveTemplateVariables.put(entry.getKey() + "[" + i + "]", arr[i]);
+				}
+			}
+		}
+		dto.setAvailableTemplateVariables(effectiveTemplateVariables);
 		return dto;
 	}
 }

--- a/src/main/java/io/oneko/project/rest/ProjectDTO.java
+++ b/src/main/java/io/oneko/project/rest/ProjectDTO.java
@@ -18,6 +18,7 @@ public class ProjectDTO {
 	private String name;
 	private String imageName;
 	private DeploymentBehaviour newVersionsDeploymentBehaviour;
+	private List<String> urlTemplates = new ArrayList<>();
 	private List<ConfigurationTemplateDTO> defaultConfigurationTemplates = new ArrayList<>();
 	private List<TemplateVariableDTO> templateVariables;
 	private UUID dockerRegistryUUID;

--- a/src/main/java/io/oneko/project/rest/ProjectDTOMapper.java
+++ b/src/main/java/io/oneko/project/rest/ProjectDTOMapper.java
@@ -64,6 +64,7 @@ public class ProjectDTOMapper {
 		dto.setImageName(project.getImageName());
 		dto.setNewVersionsDeploymentBehaviour(project.getNewVersionsDeploymentBehaviour());
 		dto.setDefaultLifetimeBehaviour(project.getDefaultLifetimeBehaviour().map(lifetimeBehaviourDTOMapper::toLifetimeBehaviourDTO).orElse(null));
+		dto.setUrlTemplates(project.getUrlTemplates());
 		dto.setDefaultConfigurationTemplates(project.getDefaultConfigurationTemplates().stream()
 				.map(templateDTOMapper::toDTO)
 				.collect(Collectors.toList()));
@@ -137,6 +138,7 @@ public class ProjectDTOMapper {
 		dto.setDeployment(DeploymentDTO.create(version.getId(), deployment));
 		dto.setUrls(version.getUrls());
 		dto.setOutdated(version.isOutdated());
+		dto.setUrlTemplates(version.getUrlTemplates());
 		dto.setConfigurationTemplates(version.getConfigurationTemplates().stream()
 				.map(templateDTOMapper::toDTO)
 				.collect(Collectors.toList()));
@@ -153,6 +155,7 @@ public class ProjectDTOMapper {
 		project.setImageName(projectDTO.getImageName());
 		project.assignToNewRegistry(registryId);
 		ofNullable(projectDTO.getNewVersionsDeploymentBehaviour()).ifPresent(project::setNewVersionsDeploymentBehaviour);
+		project.setUrlTemplates(projectDTO.getUrlTemplates());
 		project.setDefaultConfigurationTemplates(templateDTOMapper.updateFromDTOs(project.getDefaultConfigurationTemplates(), projectDTO.getDefaultConfigurationTemplates()));
 		project.setDefaultLifetimeBehaviour(ofNullable(projectDTO.getDefaultLifetimeBehaviour()).map(lifetimeBehaviourDTOMapper::toLifetimeBehaviour).orElse(null));
 		project.setTemplateVariables(fromTemplateVariableDTOs(projectDTO.getTemplateVariables()));
@@ -181,6 +184,7 @@ public class ProjectDTOMapper {
 		}
 		version.setTemplateVariables(templateVariables);
 
+		version.setUrlTemplates(projectVersionDTO.getUrlTemplates());
 		version.setConfigurationTemplates(templateDTOMapper.updateFromDTOs(version.getConfigurationTemplates(), projectVersionDTO.getConfigurationTemplates()));
 		version.setLifetimeBehaviour(ofNullable(projectVersionDTO.getLifetimeBehaviour()).filter(dto -> dto.getDaysToLive() != -1).map(lifetimeBehaviourDTOMapper::toLifetimeBehaviour).orElse(null));
 		version.setNamespace(projectVersionDTO.getNamespace());
@@ -199,9 +203,9 @@ public class ProjectDTOMapper {
 		if (deployment == null || deployment.getStatus() == DeployableStatus.NotScheduled) {
 			return false;
 		}
-		if (CollectionUtils.containsAny(version.getProject().getDirtyProperties(), Arrays.asList("defaultConfigurationTemplates", "imageName", "defaultTemplateVariables", "dockerRegistry"))) {
+		if (CollectionUtils.containsAny(version.getProject().getDirtyProperties(), Arrays.asList("defaultConfigurationTemplates", "imageName", "defaultTemplateVariables", "dockerRegistry", "urlTemplates"))) {
 			return true;
 		}
-		return CollectionUtils.containsAny(version.getDirtyProperties(), Arrays.asList("configurationTemplates", "templateVariables"));
+		return CollectionUtils.containsAny(version.getDirtyProperties(), Arrays.asList("configurationTemplates", "templateVariables", "urlTemplates"));
 	}
 }

--- a/src/main/java/io/oneko/project/rest/ProjectVersionDTO.java
+++ b/src/main/java/io/oneko/project/rest/ProjectVersionDTO.java
@@ -1,6 +1,7 @@
 package io.oneko.project.rest;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -24,6 +25,7 @@ public class ProjectVersionDTO {
 	private Map<String, String> templateVariables;
 	private DeploymentDTO deployment;
 	private List<String> urls;
+	private List<String> urlTemplates;
 	private List<ConfigurationTemplateDTO> configurationTemplates;
 	private boolean outdated;
 	private LifetimeBehaviourDTO lifetimeBehaviour;

--- a/src/main/java/io/oneko/project/rest/ProjectVersionDTO.java
+++ b/src/main/java/io/oneko/project/rest/ProjectVersionDTO.java
@@ -1,7 +1,6 @@
 package io.oneko.project.rest;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/io/oneko/project/rest/export/ProjectExportDTO.java
+++ b/src/main/java/io/oneko/project/rest/export/ProjectExportDTO.java
@@ -17,6 +17,7 @@ public class ProjectExportDTO {
 	private String name;
 	private String imageName;
 	private DeploymentBehaviour newVersionsDeploymentBehaviour;
+	private List<String> urlTemplates;
 	private List<ConfigurationTemplateDTO> defaultConfigurationTemplates;
 	private List<TemplateVariableDTO> templateVariables;
 	private UUID dockerRegistryUUID;

--- a/src/test/java/io/oneko/project/ReadableProjectTest.java
+++ b/src/test/java/io/oneko/project/ReadableProjectTest.java
@@ -23,6 +23,7 @@ class ReadableProjectTest {
                 "sample content digest",
                 Collections.emptyList(),
                 Collections.emptyList(),
+                Collections.emptyList(),
                 false,
                 LifetimeBehaviour.infinite(),
                 null,


### PR DESCRIPTION
Deployment URLs can now be defined via templates per project and versions.

Versions inherit all URLs of the project but can add custom URLs if necessary.

We no longer scan the created Kubernetes-resources for Ingress-URLs but instead write the computed URLs directly into each version.