### PR TITLE
docs: refer to our helm chart for installation instructions

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -1,5 +1,11 @@
 # O-Neko: Documentation
 
+## Quick start using Helm
+
+If you just want a quick start you can use our Helm chart to deploy O-Neko to your cluster: https://artifacthub.io/packages/helm/subshell/o-neko
+
+## More to read
+
 1. [About O-Neko](./chapters/ABOUT_ONEKO.md)
 2. [Configuring O-Neko](./chapters/CONFIGURATION.md)
 3. [Getting started](./chapters/GETTING_STARTED.md)


### PR DESCRIPTION
Just added a link to our Helm chart on artifacthub. Once https://github.com/subshell/helm-charts/pull/5 is merged this should be good I guess.

Closes #82 