### PR TITLE
deps: remove snakeyaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,11 +156,6 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.31</version>
-		</dependency>
-		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 			<version>3.4.8</version>


### PR DESCRIPTION
We have this dependency defined explicitly in the pom.xml but are no longer sure why as we don't use it in our own code. So we decided to remove it.