### PR TITLE
fix: add monaco-editor to dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "hash-it": "5.0.2",
         "lodash": "4.17.21",
         "messageformat": "2.3.0",
+        "monaco-editor": "0.34.1",
         "ngx-mat-select-search": "4.2.1",
         "ngx-monaco-editor": "12.0.0",
         "ngx-translate-messageformat-compiler": "5.1.0",
@@ -9969,6 +9970,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -22077,6 +22083,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "monaco-editor": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "hash-it": "5.0.2",
     "lodash": "4.17.21",
     "messageformat": "2.3.0",
+    "monaco-editor": "0.34.1",
     "ngx-mat-select-search": "4.2.1",
     "ngx-monaco-editor": "12.0.0",
     "ngx-translate-messageformat-compiler": "5.1.0",


### PR DESCRIPTION
apparently it is missing in our dependencies and thus the editor fails to load which is really unfortunate if you want to edit something...