### PR TITLE
fixes polling of multiplatform images

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+indent_style = space
 # ij_continuation_indent_size = 8
 # ij_formatter_off_tag = @formatter:off
 # ij_formatter_on_tag = @formatter:on
@@ -26,6 +27,7 @@ root = true
 # ij_css_value_alignment = 0
 
 [*.java]
+indent_style = tab
 # ij_java_align_consecutive_assignments = false
 # ij_java_align_consecutive_variable_declarations = false
 # ij_java_align_group_field_declarations = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM azul/zulu-openjdk-alpine:17.0.6-17.40.19-jre as builder
+FROM azul/zulu-openjdk-alpine:17.0.4.1-17.36.17-jre as builder
 
 WORKDIR /app
 ARG JAR_FILE
 ADD ${JAR_FILE} app.jar
 RUN java -Djarmode=layertools -jar app.jar extract
 
-FROM azul/zulu-openjdk-alpine:17.0.6-17.40.19-jre
+FROM azul/zulu-openjdk-alpine:17.0.4.1-17.36.17-jre
 LABEL maintainer="team-weasel@subshell.com"
 
-ARG HELM_VERSION="v3.11.0"
-ARG HELM_GCS_VERSION="0.4.0"
+ARG HELM_VERSION="v3.12.3"
+ARG HELM_GCS_VERSION="0.4.2"
 
 RUN java -Xshare:dump
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-17.36.17-jre as builder
+FROM azul/zulu-openjdk-alpine:17.0.8.1-17.44.53-jre as builder
 
 WORKDIR /app
 ARG JAR_FILE
 ADD ${JAR_FILE} app.jar
 RUN java -Djarmode=layertools -jar app.jar extract
 
-FROM azul/zulu-openjdk-alpine:17.0.4.1-17.36.17-jre
+FROM azul/zulu-openjdk-alpine:17.0.8.1-17.44.53-jre
 LABEL maintainer="team-weasel@subshell.com"
 
 ARG HELM_VERSION="v3.12.3"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ O-Neko lets everyone preview and try out new features of your software by creati
 * You need Helm charts for each project you want to deploy. The charts need to be hosted in a chart registry.
   * Currently we support standard Helm chart registries and Helm GCS
   * The Docker image tag and the image pull policy need to be configurable
-* O-Neko works with kubernetes versions 1.10.0 - 1.25.3 (these versions are *officially* supported by the Kubernetes client library we use)
+* O-Neko works with any recent kubernetes versions (according to the [Kubernetes client library we use](https://github.com/fabric8io/kubernetes-client))
 
 ## How does it work?
 

--- a/src/main/java/io/oneko/docker/v2/DockerRegistryAPIV2.java
+++ b/src/main/java/io/oneko/docker/v2/DockerRegistryAPIV2.java
@@ -1,5 +1,6 @@
 package io.oneko.docker.v2;
 
+import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 import io.oneko.docker.v2.model.ListTagsResult;
@@ -8,16 +9,19 @@ import io.oneko.docker.v2.model.manifest.DockerRegistryManifest;
 
 public interface DockerRegistryAPIV2 {
 
-	@RequestLine("GET /v2/")
-	String versionCheck();
+    @RequestLine("GET /v2/")
+    String versionCheck();
 
-	@RequestLine("GET /v2/{imageName}/tags/list")
-	ListTagsResult getAllTags(@Param("imageName") String imageName);
+    @RequestLine("GET /v2/{imageName}/tags/list")
+    ListTagsResult getAllTags(@Param("imageName") String imageName);
 
-	@RequestLine("GET /v2/{imageName}/manifests/{tagName}")
-	DockerRegistryManifest getManifest(@Param("imageName") String imageName, @Param("tagName") String tagName);
+    @RequestLine("GET /v2/{imageName}/manifests/{tagName}")
+    @Headers({
+            "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json"
+    })
+    DockerRegistryManifest getManifest(@Param("imageName") String imageName, @Param("tagName") String tagName);
 
-	@RequestLine("GET /v2/{imageName}/blobs/{algorithm}:{digest}")
-	DockerRegistryBlob getBlob(@Param("imageName") String imageName, @Param("algorithm") String algorithm, @Param("digest") String digest);
+    @RequestLine("GET /v2/{imageName}/blobs/{algorithm}:{digest}")
+    DockerRegistryBlob getBlob(@Param("imageName") String imageName, @Param("algorithm") String algorithm, @Param("digest") String digest);
 
 }

--- a/src/main/java/io/oneko/docker/v2/DockerRegistryAPIV2.java
+++ b/src/main/java/io/oneko/docker/v2/DockerRegistryAPIV2.java
@@ -9,19 +9,19 @@ import io.oneko.docker.v2.model.manifest.DockerRegistryManifest;
 
 public interface DockerRegistryAPIV2 {
 
-    @RequestLine("GET /v2/")
-    String versionCheck();
+	@RequestLine("GET /v2/")
+	String versionCheck();
 
-    @RequestLine("GET /v2/{imageName}/tags/list")
-    ListTagsResult getAllTags(@Param("imageName") String imageName);
+	@RequestLine("GET /v2/{imageName}/tags/list")
+	ListTagsResult getAllTags(@Param("imageName") String imageName);
 
-    @RequestLine("GET /v2/{imageName}/manifests/{tagName}")
-    @Headers({
-            "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json"
-    })
-    DockerRegistryManifest getManifest(@Param("imageName") String imageName, @Param("tagName") String tagName);
+	@RequestLine("GET /v2/{imageName}/manifests/{tagName}")
+	@Headers({
+		"Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json"
+	})
+	DockerRegistryManifest getManifest(@Param("imageName") String imageName, @Param("tagName") String tagName);
 
-    @RequestLine("GET /v2/{imageName}/blobs/{algorithm}:{digest}")
-    DockerRegistryBlob getBlob(@Param("imageName") String imageName, @Param("algorithm") String algorithm, @Param("digest") String digest);
+	@RequestLine("GET /v2/{imageName}/blobs/{algorithm}:{digest}")
+	DockerRegistryBlob getBlob(@Param("imageName") String imageName, @Param("algorithm") String algorithm, @Param("digest") String digest);
 
 }

--- a/src/main/java/io/oneko/docker/v2/DockerRegistryV2Client.java
+++ b/src/main/java/io/oneko/docker/v2/DockerRegistryV2Client.java
@@ -40,110 +40,110 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 @Slf4j
 public class DockerRegistryV2Client {
 
-    private final DockerRegistryAPIV2 feignClient;
-    private final MetersPerRegistry meters;
+	private final DockerRegistryAPIV2 feignClient;
+	private final MetersPerRegistry meters;
 
-    public DockerRegistryV2Client(DockerRegistry registry,
-                                  String token,
-                                  ObjectMapper objectMapper,
-                                  MetersPerRegistry meters) {
-        this.meters = meters;
-        List<Header> defaultHeaders = new ArrayList<>();
-        defaultHeaders.add(new BasicHeader("Accept", "*/*"));
-        if (token != null) {
-            defaultHeaders.add(new BasicHeader(AuthorizationHeader.KEY, AuthorizationHeader.bearer(token)));
-        }
-        var builder = HttpClients.custom()
-                .setDefaultRequestConfig(RequestConfig.custom()
-                        .setCookieSpec(CookieSpecs.STANDARD)
-                        .build())
-                .setDefaultHeaders(defaultHeaders);
-        if (registry.isTrustInsecureCertificate()) {
-            builder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
-        }
-        final var client = builder.build();
-        this.feignClient = Feign.builder()
-                .decoder(new JacksonDecoder(objectMapper))
-                .encoder(new JacksonEncoder(objectMapper))
-                .logger(new Slf4jLogger())
-                .client(new ApacheHttpClient(client))
-                .target(DockerRegistryAPIV2.class, registry.getRegistryUrl());
-    }
+	public DockerRegistryV2Client(DockerRegistry registry,
+								  String token,
+								  ObjectMapper objectMapper,
+								  MetersPerRegistry meters) {
+		this.meters = meters;
+		List<Header> defaultHeaders = new ArrayList<>();
+		defaultHeaders.add(new BasicHeader("Accept", "*/*"));
+		if (token != null) {
+			defaultHeaders.add(new BasicHeader(AuthorizationHeader.KEY, AuthorizationHeader.bearer(token)));
+		}
+		var builder = HttpClients.custom()
+			.setDefaultRequestConfig(RequestConfig.custom()
+				.setCookieSpec(CookieSpecs.STANDARD)
+				.build())
+			.setDefaultHeaders(defaultHeaders);
+		if (registry.isTrustInsecureCertificate()) {
+			builder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+		}
+		final var client = builder.build();
+		this.feignClient = Feign.builder()
+			.decoder(new JacksonDecoder(objectMapper))
+			.encoder(new JacksonEncoder(objectMapper))
+			.logger(new Slf4jLogger())
+			.client(new ApacheHttpClient(client))
+			.target(DockerRegistryAPIV2.class, registry.getRegistryUrl());
+	}
 
-    public String versionCheck() {
-        final Timer.Sample sample = Timer.start();
-        try {
-            final String result = feignClient.versionCheck();
-            sample.stop(meters.getVersionCheckTimerOk());
-            return result;
-        } catch (FeignException e) {
-            sample.stop(meters.getVersionCheckTimerError());
-            log.warn("failed to check docker registry version", e);
-            throw e;
-        }
-    }
+	public String versionCheck() {
+		final Timer.Sample sample = Timer.start();
+		try {
+			final String result = feignClient.versionCheck();
+			sample.stop(meters.getVersionCheckTimerOk());
+			return result;
+		} catch (FeignException e) {
+			sample.stop(meters.getVersionCheckTimerError());
+			log.warn("failed to check docker registry version", e);
+			throw e;
+		}
+	}
 
-    public List<String> getAllTags(Project<?, ?> project) {
-        final Timer.Sample sample = Timer.start();
-        try {
-            final List<String> result = feignClient.getAllTags(project.getImageName()).getTags();
-            sample.stop(meters.getListAllTagsTimerOk());
-            return result;
-        } catch (FeignException e) {
-            sample.stop(meters.getListAllTagsTimerError());
-            log.warn("failed to list all container image tags ({})", kv("image_name", project.getImageName()), e);
-            throw e;
-        }
-    }
+	public List<String> getAllTags(Project<?, ?> project) {
+		final Timer.Sample sample = Timer.start();
+		try {
+			final List<String> result = feignClient.getAllTags(project.getImageName()).getTags();
+			sample.stop(meters.getListAllTagsTimerOk());
+			return result;
+		} catch (FeignException e) {
+			sample.stop(meters.getListAllTagsTimerError());
+			log.warn("failed to list all container image tags ({})", kv("image_name", project.getImageName()), e);
+			throw e;
+		}
+	}
 
-    public Manifest getManifest(ProjectVersion<?, ?> version) {
-        final Timer.Sample sample = Timer.start();
-        try {
-            final String imageName = version.getProject().getImageName();
-            final DockerRegistryManifest dockerRegistryManifest = feignClient.getManifest(imageName, version.getName());
+	public Manifest getManifest(ProjectVersion<?, ?> version) {
+		final Timer.Sample sample = Timer.start();
+		try {
+			final String imageName = version.getProject().getImageName();
+			final DockerRegistryManifest dockerRegistryManifest = feignClient.getManifest(imageName, version.getName());
 
-            Manifest result = null;
-            if (dockerRegistryManifest.isManifestList()) {
-                result = generateManifestFromManifestList(imageName, dockerRegistryManifest);
-            } else {
-                final DockerRegistryManifest.Digest digest = dockerRegistryManifest.getDigest();
-                final DockerRegistryBlob blob = feignClient.getBlob(imageName, digest.getAlgorithm(), digest.getDigest());
-                result = new Manifest(digest.getFullDigest(), blob.getCreated());
-            }
-            sample.stop(meters.getGetManifestTimerOk());
-            return result;
-        } catch (FeignException e) {
-            sample.stop(meters.getGetManifestTimerError());
-            log.warn("failed to get manifest for project version ({}, {})", versionKv(version), projectKv(version.getProject()), e);
-            throw e;
-        }
-    }
+			Manifest result = null;
+			if (dockerRegistryManifest.isManifestList()) {
+				result = generateManifestFromManifestList(imageName, dockerRegistryManifest);
+			} else {
+				final DockerRegistryManifest.Digest digest = dockerRegistryManifest.getDigest();
+				final DockerRegistryBlob blob = feignClient.getBlob(imageName, digest.getAlgorithm(), digest.getDigest());
+				result = new Manifest(digest.getFullDigest(), blob.getCreated());
+			}
+			sample.stop(meters.getGetManifestTimerOk());
+			return result;
+		} catch (FeignException e) {
+			sample.stop(meters.getGetManifestTimerError());
+			log.warn("failed to get manifest for project version ({}, {})", versionKv(version), projectKv(version.getProject()), e);
+			throw e;
+		}
+	}
 
-    /*
-     * This method generates a "pseudo-manifest" for an image that is actually a manifest list (e.g. multiplatform image).
-     * It gets the actual manifests and then the blogs. Then it takes the latest modification date found in the manifests
-     * and creates a hash of all manifest hashes.
-     */
-    public Manifest generateManifestFromManifestList(String imageName, DockerRegistryManifest manifestList) {
-        return manifestList.getManifests()
-                .stream()
-                .map(m -> feignClient.getManifest(imageName, m.getDigest().getFullDigest()))
-                .map(m -> {
-                    if (m.isManifestList()) {
-                        throw new IllegalStateException("received manifest list after getting manifest from manifest list");
-                    }
-                    DockerRegistryBlob blob = feignClient.getBlob(imageName, m.getDigest().getAlgorithm(), m.getDigest().getDigest());
-                    return new Manifest(m.getDigest().getFullDigest(), blob.getCreated());
-                }).reduce((m1, m2) -> {
-                    String hash = "sha512:" + Hashing.sha512().hashString(m1.getDockerContentDigest() + m2.getDockerContentDigest(), StandardCharsets.UTF_8).toString();
-                    Instant date = m1.getImageUpdatedDate().map(d -> {
-                        if (m2.getImageUpdatedDate().isPresent() && d.isBefore(m2.getImageUpdatedDate().get())) {
-                            return m2.getImageUpdatedDate().get();
-                        }
-                        return d;
-                    }).orElse(Instant.MIN);
-                    return new Manifest(hash, date);
-                }).orElseThrow();
-    }
+	/*
+	 * This method generates a "pseudo-manifest" for an image that is actually a manifest list (e.g. multiplatform image).
+	 * It gets the actual manifests and then the blogs. Then it takes the latest modification date found in the manifests
+	 * and creates a hash of all manifest hashes.
+	 */
+	public Manifest generateManifestFromManifestList(String imageName, DockerRegistryManifest manifestList) {
+		return manifestList.getManifests()
+			.stream()
+			.map(m -> feignClient.getManifest(imageName, m.getDigest().getFullDigest()))
+			.map(m -> {
+				if (m.isManifestList()) {
+					throw new IllegalStateException("received manifest list after getting manifest from manifest list");
+				}
+				DockerRegistryBlob blob = feignClient.getBlob(imageName, m.getDigest().getAlgorithm(), m.getDigest().getDigest());
+				return new Manifest(m.getDigest().getFullDigest(), blob.getCreated());
+			}).reduce((m1, m2) -> {
+				String hash = "sha512:" + Hashing.sha512().hashString(m1.getDockerContentDigest() + m2.getDockerContentDigest(), StandardCharsets.UTF_8).toString();
+				Instant date = m1.getImageUpdatedDate().map(d -> {
+					if (m2.getImageUpdatedDate().isPresent() && d.isBefore(m2.getImageUpdatedDate().get())) {
+						return m2.getImageUpdatedDate().get();
+					}
+					return d;
+				}).orElse(Instant.MIN);
+				return new Manifest(hash, date);
+			}).orElseThrow();
+	}
 
 }

--- a/src/main/java/io/oneko/docker/v2/DockerRegistryV2Client.java
+++ b/src/main/java/io/oneko/docker/v2/DockerRegistryV2Client.java
@@ -1,20 +1,7 @@
 package io.oneko.docker.v2;
 
-import static io.oneko.util.MoreStructuredArguments.*;
-import static net.logstash.logback.argument.StructuredArguments.*;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.http.Header;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import com.google.common.hash.Hashing;
 import feign.Feign;
 import feign.FeignException;
 import feign.httpclient.ApacheHttpClient;
@@ -30,6 +17,21 @@ import io.oneko.docker.v2.model.manifest.Manifest;
 import io.oneko.project.Project;
 import io.oneko.project.ProjectVersion;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.Header;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.oneko.util.MoreStructuredArguments.projectKv;
+import static io.oneko.util.MoreStructuredArguments.versionKv;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 /**
  * Accesses the API defined here:
@@ -38,76 +40,110 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DockerRegistryV2Client {
 
-	private final DockerRegistryAPIV2 feignClient;
-	private final MetersPerRegistry meters;
+    private final DockerRegistryAPIV2 feignClient;
+    private final MetersPerRegistry meters;
 
-	public DockerRegistryV2Client(DockerRegistry registry,
-																String token,
-																ObjectMapper objectMapper,
-																MetersPerRegistry meters) {
-		this.meters = meters;
-		List<Header> defaultHeaders = new ArrayList<>();
-		defaultHeaders.add(new BasicHeader("Accept", "*/*"));
-		if (token != null) {
-			defaultHeaders.add(new BasicHeader(AuthorizationHeader.KEY, AuthorizationHeader.bearer(token)));
-		}
-		var builder = HttpClients.custom()
-				.setDefaultRequestConfig(RequestConfig.custom()
-						.setCookieSpec(CookieSpecs.STANDARD)
-						.build())
-				.setDefaultHeaders(defaultHeaders);
-		if (registry.isTrustInsecureCertificate()) {
-			builder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
-		}
-		final var client = builder.build();
-		this.feignClient = Feign.builder()
-				.decoder(new JacksonDecoder(objectMapper))
-				.encoder(new JacksonEncoder(objectMapper))
-				.logger(new Slf4jLogger())
-				.client(new ApacheHttpClient(client))
-				.target(DockerRegistryAPIV2.class, registry.getRegistryUrl());
-	}
+    public DockerRegistryV2Client(DockerRegistry registry,
+                                  String token,
+                                  ObjectMapper objectMapper,
+                                  MetersPerRegistry meters) {
+        this.meters = meters;
+        List<Header> defaultHeaders = new ArrayList<>();
+        defaultHeaders.add(new BasicHeader("Accept", "*/*"));
+        if (token != null) {
+            defaultHeaders.add(new BasicHeader(AuthorizationHeader.KEY, AuthorizationHeader.bearer(token)));
+        }
+        var builder = HttpClients.custom()
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setCookieSpec(CookieSpecs.STANDARD)
+                        .build())
+                .setDefaultHeaders(defaultHeaders);
+        if (registry.isTrustInsecureCertificate()) {
+            builder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+        }
+        final var client = builder.build();
+        this.feignClient = Feign.builder()
+                .decoder(new JacksonDecoder(objectMapper))
+                .encoder(new JacksonEncoder(objectMapper))
+                .logger(new Slf4jLogger())
+                .client(new ApacheHttpClient(client))
+                .target(DockerRegistryAPIV2.class, registry.getRegistryUrl());
+    }
 
-	public String versionCheck() {
-		final Timer.Sample sample = Timer.start();
-		try {
-			final String result = feignClient.versionCheck();
-			sample.stop(meters.getVersionCheckTimerOk());
-			return result;
-		} catch (FeignException e) {
-			sample.stop(meters.getVersionCheckTimerError());
-			log.warn("failed to check docker registry version", e);
-			throw e;
-		}
-	}
+    public String versionCheck() {
+        final Timer.Sample sample = Timer.start();
+        try {
+            final String result = feignClient.versionCheck();
+            sample.stop(meters.getVersionCheckTimerOk());
+            return result;
+        } catch (FeignException e) {
+            sample.stop(meters.getVersionCheckTimerError());
+            log.warn("failed to check docker registry version", e);
+            throw e;
+        }
+    }
 
-	public List<String> getAllTags(Project<?, ?> project) {
-		final Timer.Sample sample = Timer.start();
-		try {
-			final List<String> result = feignClient.getAllTags(project.getImageName()).getTags();
-			sample.stop(meters.getListAllTagsTimerOk());
-			return result;
-		} catch (FeignException e) {
-			sample.stop(meters.getListAllTagsTimerError());
-			log.warn("failed to list all container image tags ({})", kv("image_name", project.getImageName()), e);
-			throw e;
-		}
-	}
+    public List<String> getAllTags(Project<?, ?> project) {
+        final Timer.Sample sample = Timer.start();
+        try {
+            final List<String> result = feignClient.getAllTags(project.getImageName()).getTags();
+            sample.stop(meters.getListAllTagsTimerOk());
+            return result;
+        } catch (FeignException e) {
+            sample.stop(meters.getListAllTagsTimerError());
+            log.warn("failed to list all container image tags ({})", kv("image_name", project.getImageName()), e);
+            throw e;
+        }
+    }
 
-	public Manifest getManifest(ProjectVersion<?, ?> version) {
-		final Timer.Sample sample = Timer.start();
-		try {
-			final String imageName = version.getProject().getImageName();
-			final DockerRegistryManifest dockerRegistryManifest = feignClient.getManifest(imageName, version.getName());
-			final DockerRegistryManifest.Digest digest = dockerRegistryManifest.getDigest();
-			final DockerRegistryBlob blob = feignClient.getBlob(imageName, digest.getAlgorithm(), digest.getDigest());
-			sample.stop(meters.getGetManifestTimerOk());
-			return new Manifest(digest.getFullDigest(), blob.getCreated());
-		} catch (FeignException e) {
-			sample.stop(meters.getGetManifestTimerError());
-			log.warn("failed to get manifest for project version ({}, {})", versionKv(version), projectKv(version.getProject()), e);
-			throw e;
-		}
-	}
+    public Manifest getManifest(ProjectVersion<?, ?> version) {
+        final Timer.Sample sample = Timer.start();
+        try {
+            final String imageName = version.getProject().getImageName();
+            final DockerRegistryManifest dockerRegistryManifest = feignClient.getManifest(imageName, version.getName());
+
+            Manifest result = null;
+            if (dockerRegistryManifest.isManifestList()) {
+                result = generateManifestFromManifestList(imageName, dockerRegistryManifest);
+            } else {
+                final DockerRegistryManifest.Digest digest = dockerRegistryManifest.getDigest();
+                final DockerRegistryBlob blob = feignClient.getBlob(imageName, digest.getAlgorithm(), digest.getDigest());
+                result = new Manifest(digest.getFullDigest(), blob.getCreated());
+            }
+            sample.stop(meters.getGetManifestTimerOk());
+            return result;
+        } catch (FeignException e) {
+            sample.stop(meters.getGetManifestTimerError());
+            log.warn("failed to get manifest for project version ({}, {})", versionKv(version), projectKv(version.getProject()), e);
+            throw e;
+        }
+    }
+
+    /*
+     * This method generates a "pseudo-manifest" for an image that is actually a manifest list (e.g. multiplatform image).
+     * It gets the actual manifests and then the blogs. Then it takes the latest modification date found in the manifests
+     * and creates a hash of all manifest hashes.
+     */
+    public Manifest generateManifestFromManifestList(String imageName, DockerRegistryManifest manifestList) {
+        return manifestList.getManifests()
+                .stream()
+                .map(m -> feignClient.getManifest(imageName, m.getDigest().getFullDigest()))
+                .map(m -> {
+                    if (m.isManifestList()) {
+                        throw new IllegalStateException("received manifest list after getting manifest from manifest list");
+                    }
+                    DockerRegistryBlob blob = feignClient.getBlob(imageName, m.getDigest().getAlgorithm(), m.getDigest().getDigest());
+                    return new Manifest(m.getDigest().getFullDigest(), blob.getCreated());
+                }).reduce((m1, m2) -> {
+                    String hash = "sha512:" + Hashing.sha512().hashString(m1.getDockerContentDigest() + m2.getDockerContentDigest(), StandardCharsets.UTF_8).toString();
+                    Instant date = m1.getImageUpdatedDate().map(d -> {
+                        if (m2.getImageUpdatedDate().isPresent() && d.isBefore(m2.getImageUpdatedDate().get())) {
+                            return m2.getImageUpdatedDate().get();
+                        }
+                        return d;
+                    }).orElse(Instant.MIN);
+                    return new Manifest(hash, date);
+                }).orElseThrow();
+    }
 
 }

--- a/src/main/java/io/oneko/docker/v2/model/manifest/DockerRegistryManifest.java
+++ b/src/main/java/io/oneko/docker/v2/model/manifest/DockerRegistryManifest.java
@@ -60,7 +60,7 @@ public class DockerRegistryManifest {
         if (!isManifestList()) {
             return new Digest(config.digest);
         }
-        throw new IllegalStateException("unsupported mediaType: " + mediaType);
+        throw new IllegalStateException("tried to receive single digest from manifest list");
     }
 
     public boolean isManifestList() {

--- a/src/main/java/io/oneko/docker/v2/model/manifest/DockerRegistryManifest.java
+++ b/src/main/java/io/oneko/docker/v2/model/manifest/DockerRegistryManifest.java
@@ -9,61 +9,61 @@ import java.util.List;
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerRegistryManifest {
-    @Data
-    static class Config {
-        String digest;
-        String mediaType;
-        int size;
-    }
+	@Data
+	static class Config {
+		String digest;
+		String mediaType;
+		int size;
+	}
 
-    @Data
-    static class Platform {
-        String architecture;
-        String os;
-    }
+	@Data
+	static class Platform {
+		String architecture;
+		String os;
+	}
 
-    @Data
-    public static class Manifest {
-        String digest;
-        String mediaType;
-        Platform platform;
-        int size;
+	@Data
+	public static class Manifest {
+		String digest;
+		String mediaType;
+		Platform platform;
+		int size;
 
-        public Digest getDigest() {
-            return new Digest(digest);
-        }
-    }
+		public Digest getDigest() {
+			return new Digest(digest);
+		}
+	}
 
-    @Data
-    public static class Digest {
-        String algorithm;
-        String digest;
+	@Data
+	public static class Digest {
+		String algorithm;
+		String digest;
 
-        public Digest(String digest) {
-            final String[] split = StringUtils.defaultString(digest).split(":");
-            this.algorithm = StringUtils.defaultString(split[0]);
-            this.digest = StringUtils.defaultString(split[1]);
-        }
+		public Digest(String digest) {
+			final String[] split = StringUtils.defaultString(digest).split(":");
+			this.algorithm = StringUtils.defaultString(split[0]);
+			this.digest = StringUtils.defaultString(split[1]);
+		}
 
-        public String getFullDigest() {
-            return algorithm + ":" + digest;
-        }
-    }
-
-
-    private String mediaType;
-    private Config config;
-    private List<Manifest> manifests;
+		public String getFullDigest() {
+			return algorithm + ":" + digest;
+		}
+	}
 
 
-    public Digest getDigest() {
-        if (!isManifestList()) {
-            return new Digest(config.digest);
-        }
-        throw new IllegalStateException("tried to receive single digest from manifest list");
-    }
+	private String mediaType;
+	private Config config;
+	private List<Manifest> manifests;
 
-    public boolean isManifestList() {
-        return manifests != null && !manifests.isEmpty();
-    }
+
+	public Digest getDigest() {
+		if (!isManifestList()) {
+			return new Digest(config.digest);
+		}
+		throw new IllegalStateException("tried to receive single digest from manifest list");
+	}
+
+	public boolean isManifestList() {
+		return manifests != null && !manifests.isEmpty();
+	}
 }

--- a/src/main/java/io/oneko/docker/v2/model/manifest/DockerRegistryManifest.java
+++ b/src/main/java/io/oneko/docker/v2/model/manifest/DockerRegistryManifest.java
@@ -1,39 +1,69 @@
 package io.oneko.docker.v2.model.manifest;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-import lombok.Data;
+import java.util.List;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerRegistryManifest {
+    @Data
+    static class Config {
+        String digest;
+        String mediaType;
+        int size;
+    }
 
-	@Data
-	static class Config {
-		String digest;
-	}
+    @Data
+    static class Platform {
+        String architecture;
+        String os;
+    }
 
-	@Data
-	public static class Digest {
-		String algorithm;
-		String digest;
+    @Data
+    public static class Manifest {
+        String digest;
+        String mediaType;
+        Platform platform;
+        int size;
 
-		public Digest(String digest) {
-			final String[] split = StringUtils.defaultString(digest).split(":");
-			this.algorithm = StringUtils.defaultString(split[0]);
-			this.digest = StringUtils.defaultString(split[1]);
-		}
+        public Digest getDigest() {
+            return new Digest(digest);
+        }
+    }
 
-		public String getFullDigest() {
-			return algorithm + ":" + digest;
-		}
-	}
+    @Data
+    public static class Digest {
+        String algorithm;
+        String digest;
 
-	private Config config;
+        public Digest(String digest) {
+            final String[] split = StringUtils.defaultString(digest).split(":");
+            this.algorithm = StringUtils.defaultString(split[0]);
+            this.digest = StringUtils.defaultString(split[1]);
+        }
 
-	public Digest getDigest() {
-		return new Digest(config.digest);
-	}
+        public String getFullDigest() {
+            return algorithm + ":" + digest;
+        }
+    }
+
+
+    private String mediaType;
+    private Config config;
+    private List<Manifest> manifests;
+
+
+    public Digest getDigest() {
+        if (!isManifestList()) {
+            return new Digest(config.digest);
+        }
+        throw new IllegalStateException("unsupported mediaType: " + mediaType);
+    }
+
+    public boolean isManifestList() {
+        return manifests != null && !manifests.isEmpty();
+    }
 }


### PR DESCRIPTION
This PR fixes the polling of multiplatform images by creating a pseudo-manifest O-Neko can work with and pretend like it's actually a real image-manifest.

This is a quick fix for the current issues. A larger solution would be to support container manifest lists natively and also show this in the UI, grouping the images belonging to a manifest somehow with the actual manifest. But as that would require a lot of work in the backend and the frontend and is currently not a strong requirement, we should stick with this fix.